### PR TITLE
Fix .close() after switch to subprocess

### DIFF
--- a/lib/testium-core.js
+++ b/lib/testium-core.js
@@ -50,7 +50,7 @@ function initTestium() {
     function close() {
       _.each(procs, function(proc, name) {
         try {
-          proc.kill();
+          proc.rawProcess.kill();
         } catch (e) {
           debug('Error killing process %s', name, e);
         }


### PR DESCRIPTION
`proc.kill` isn't actually a function anymore because `subprocess` returns a wrapper object, not the raw process handle directly.