### PR TITLE
Fix handling of external urls

### DIFF
--- a/lib/testium-core.js
+++ b/lib/testium-core.js
@@ -39,6 +39,10 @@ function getNewPageUrl(commandUrl, url, options) {
     }
     url = extendUrlWithQuery(url, query);
   }
+  // We don't support absolute urls in proxy (~= starting with a protocol)
+  if (/^[\w]+:\/\//.test(url)) {
+    return url;
+  }
   options = _.defaults({ url: url, redirect: true }, _.omit(options, 'query'));
   return commandUrl + '/new-page?' + qs.stringify(options);
 }

--- a/test/testium-core.js
+++ b/test/testium-core.js
@@ -22,6 +22,10 @@ tap.test('Init against hello-world', function(t) {
   initTestium()
     .then(function(_testium) { testium = _testium; })
     .then(function() {
+      t.equal(testium.getNewPageUrl('https://www.example.com', {
+        query: { a: 'b' }
+      }), 'https://www.example.com/?a=b');
+
       return fetch(testium.getInitialUrl());
     })
     .then(function(result) {


### PR DESCRIPTION
The proxy doesn't support external urls, so we shouldn't use the proxy when someone `navigateTo`'s an external url.