### PR TITLE
Prefer browser.quit for wd's sake

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -66,7 +66,11 @@ function initTestium(config) {
     var testium;
 
     function closeSeleniumSession() {
-      return testium.browser && testium.browser.close();
+      var browser = testium.browser;
+      if (browser && typeof browser.quit === 'function') {
+        return browser.quit();
+      }
+      return browser && browser.close();
     }
 
     function killAllProcesses() {


### PR DESCRIPTION
`wd` already has a `.close()` method that means "close the current window" while `.quit()` means "tear down everything and close the session".