### PR TITLE
Default proxy port to 4445

### DIFF
--- a/lib/processes/proxy/index.js
+++ b/lib/processes/proxy/index.js
@@ -28,7 +28,8 @@ function getProxyOptions(config) {
     };
   }
 
-  var port = config.get('proxy.port', 0);
+  // Defaulting to 4445 for backward compatibility
+  var port = config.get('proxy.port', 4445);
 
   if (port === 0) {
     return findOpenPort().then(buildOptionsFromPort);


### PR DESCRIPTION
Some people hard-code the resulting URLs in their tests. Let's not break their tests if we don't have to.