### PR TITLE
Fix regression: Honor app.port when using launch=false

### DIFF
--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -33,7 +33,7 @@ module.exports = function getDefaults() {
 
     app: {
       // A port of 0 means "auto-select available port"
-      port: process.env.PORT || 0,
+      port: process.env.PORT || undefined,
       // How long to wait for the app to start listening
       timeout: 30000,
       // Command to start the app.

--- a/lib/processes.js
+++ b/lib/processes.js
@@ -34,7 +34,7 @@ function launchAllProcesses(config) {
       debug('Launching app');
       servers.push(App);
     } else {
-      debug('Using already running application');
+      debug('Using already running application on port %d', appPort);
     }
 
     var seleniumUrl = config.get('selenium.serverUrl', false);
@@ -50,7 +50,7 @@ function launchAllProcesses(config) {
   }
 
   // app.port is special because the proxy needs to know it
-  var appPort = launchApp ? config.get('app.port', 0) : -1;
+  var appPort = config.get('app.port', launchApp ? 0 : -1);
   if (appPort === 0) {
     return findOpenPort().then(launchWithAppPort);
   }

--- a/lib/testium-core.js
+++ b/lib/testium-core.js
@@ -35,9 +35,8 @@ function getTestium(options) {
   var keepCookies = localConfig.get('keepCookies', false);
   var driverFactory = resolveDriver(localConfig.get('driver', 'sync'));
 
-  var launchApp = config.get('launch', false);
   var isExistingSession = reuseSession && !!driverFactory.instance;
-  var skipPriming = !launchApp || isExistingSession;
+  var skipPriming = isExistingSession;
   if (skipPriming) {
     debug('Skipping priming load');
   }


### PR DESCRIPTION
Just because someone isn't launching the app, doesn't mean it doesn't exist.