### PR TITLE
Fix regression: Restore page size during getTestium

### DIFF
--- a/lib/testium-core.js
+++ b/lib/testium-core.js
@@ -11,12 +11,15 @@ var resolveDriver = require('./driver-factory');
 var initTestiumOnce = _.once(initTestium);
 var getConfig = _.once(Config.load);
 
+var DEFAULT_PAGE_SIZE = { height: 768, width: 1024 };
+
 // For backwards-compatibility
 module.exports = initTestium;
 
 function clearCookies(testium) {
   return Bluebird
     .try(_.bindKey(testium.browser, 'clearCookies'))
+    .then(_.partial(debug, 'Cookies cleared'))
     .then(_.constant(testium));
 }
 
@@ -24,6 +27,14 @@ function primingLoad(testium) {
   return Bluebird
     .try(_.bindKey(testium.browser, 'navigateTo', testium.getInitialUrl()))
     .then(_.partial(debug, 'Browser was primed'))
+    .then(_.constant(testium));
+}
+
+function resetViewport(testium) {
+  var pageSize = testium.config.get('defaultPageSize', DEFAULT_PAGE_SIZE);
+  return Bluebird
+    .try(_.bindKey(testium.browser, 'setPageSize', pageSize))
+    .then(_.partial(debug, 'View reset to default size', pageSize))
     .then(_.constant(testium));
 }
 
@@ -55,6 +66,7 @@ function getTestium(options) {
 
   return initTestiumOnce(config)
     .then(reuseSession ? driverFactory.once : driverFactory.create)
+    .then(resetViewport)
     .then(keepCookies ? _.identity : clearCookies)
     .then(skipPriming ? _.identity : primingLoad)
     .catch(generateDriverError);

--- a/test/testium-core.js
+++ b/test/testium-core.js
@@ -2,7 +2,7 @@ import assert from 'assertive';
 import Gofer from 'gofer';
 import Bluebird from 'bluebird';
 
-import TestiumCore from '../';
+import {getTestium, getBrowser} from '../';
 
 const gofer = new Gofer({
   globalDefaults: {},
@@ -17,7 +17,7 @@ function fetchResponse(uri, options) {
 describe('testium-core', () => {
   let testium;
   before(async () => {
-    testium = await TestiumCore.getTestium();
+    testium = await getTestium();
   });
 
   after(() => testium && testium.close());
@@ -59,9 +59,36 @@ describe('testium-core', () => {
 
   describe('basic navigation', () => {
     it('can navigate to /index.html', async () => {
-      const browser = await TestiumCore.getBrowser();
+      const browser = await getBrowser();
       browser.navigateTo('/index.html');
       assert.equal('Test Title', browser.getPageTitle());
+    });
+  });
+
+  describe('cross-test side effects', () => {
+    describe('changes page size', () => {
+      before(async () => {
+        testium = await getTestium();
+      });
+
+      it('leaves a dirty state', () =>
+        testium.browser.setPageSize({ width: 600, height: 800 }));
+
+      it('can read its own changes', async () => {
+        const pageSize = await testium.browser.getPageSize();
+        assert.deepEqual({ width: 600, height: 800 }, pageSize);
+      });
+    });
+
+    describe('expects original page size', () => {
+      before(async () => {
+        testium = await getTestium();
+      });
+
+      it('sees the default page size', async () => {
+        const pageSize = await testium.browser.getPageSize();
+        assert.deepEqual({ height: 768, width: 1024 }, pageSize);
+      });
     });
   });
 });


### PR DESCRIPTION
This prevents `.setPageSize` calls from one test to leak into other tests. This restores the previous behavior of testium.