### PR TITLE
Fix handling of urls hash segment

### DIFF
--- a/lib/processes/proxy/proxy.js
+++ b/lib/processes/proxy/proxy.js
@@ -26,12 +26,8 @@ function buildRemoteRequestOptions(request, toPort) {
   return opt;
 }
 
-function trimHash(url) {
-  return url.split('#')[0];
-}
-
 function normalizeOptions(options) {
-  options.url = trimHash(options.url || '/');
+  options.url = options.url || '/';
   options.redirect = options.redirect === true || options.redirect === 'true';
   return options;
 }

--- a/test/testium-core.js
+++ b/test/testium-core.js
@@ -63,6 +63,14 @@ describe('testium-core', () => {
       browser.navigateTo('/index.html');
       assert.equal('Test Title', browser.getPageTitle());
     });
+
+    it('preserves #hash segments of the url', async () => {
+      const browser = await getBrowser();
+      browser.navigateTo('/#!/foo?yes=it-is');
+      assert.equal('Test Title', browser.getPageTitle());
+      const hash = browser.evaluate('return "" + window.location.hash;');
+      assert.equal('#!/foo?yes=it-is', hash);
+    });
   });
 
   describe('cross-test side effects', () => {


### PR DESCRIPTION
The previous behavior was correct before we started redirecting. Now dropping the hash just means that it gets lost.