### PR TITLE
[WIP] Support for proxying all urls

### DIFF
--- a/.testiumrc
+++ b/.testiumrc
@@ -2,5 +2,8 @@
   "launch": true,
   "app": {
     "command": "testium-example-app"
+  },
+  "proxy": {
+    "proxyType": "manual"
   }
 }

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -40,6 +40,9 @@ module.exports = function getDefaults() {
       // `undefined` means testium will simulate `npm start`
       command: undefined,
     },
+    proxy: {
+      proxyType: 'direct',
+    },
     phantomjs: {
       // Command to start phantomjs
       // Change this if you don't have phantomjs in your PATH

--- a/lib/init.js
+++ b/lib/init.js
@@ -41,12 +41,8 @@ function getNewPageUrl(commandUrl, url, options) {
     }
     url = extendUrlWithQuery(url, query);
   }
-  // We don't support absolute urls in proxy (~= starting with a protocol)
-  if (/^[\w]+:\/\//.test(url)) {
-    return url;
-  }
   options = _.defaults({ url: url, redirect: true }, _.omit(options, 'query'));
-  return commandUrl + '/new-page?' + qs.stringify(options);
+  return commandUrl + '/testium-new-page?' + qs.stringify(options);
 }
 
 function isTruthyConfig(setting) {

--- a/lib/processes.js
+++ b/lib/processes.js
@@ -3,6 +3,7 @@
 var findOpenPort = require('find-open-port');
 var _ = require('lodash');
 var debug = require('debug')('testium-core:processes');
+var Bluebird = require('bluebird');
 
 var spawnServers = require('./spawn-server');
 
@@ -22,8 +23,9 @@ function unrefAll(procs) {
 function launchAllProcesses(config) {
   var launchApp = config.getBool('launch', false);
 
-  function launchWithAppPort(appPort) {
+  function launchWithPorts(appPort, proxyPort) {
     config.set('app.port', appPort);
+    config.set('proxy.port', proxyPort);
 
     var browserName = config.get('browser');
     config.set('desiredCapabilities.browserName', browserName);
@@ -51,9 +53,10 @@ function launchAllProcesses(config) {
 
   // app.port is special because the proxy needs to know it
   var appPort = config.get('app.port', launchApp ? 0 : -1);
-  if (appPort === 0) {
-    return findOpenPort().then(launchWithAppPort);
-  }
-  return launchWithAppPort(appPort);
+  var proxyPort = config.get('proxy.port', 4445);
+  return Bluebird.all([
+    appPort === 0 ? findOpenPort() : appPort,
+    proxyPort === 0 ? findOpenPort() : proxyPort,
+  ]).spread(launchWithPorts);
 }
 module.exports = launchAllProcesses;

--- a/lib/processes/phantom/index.js
+++ b/lib/processes/phantom/index.js
@@ -10,13 +10,20 @@ function getPhantomOptions(config) {
     config.set('phantomjs.port', port);
     config.set('selenium.serverUrl', 'http://127.0.0.1:' + port + '/wd/hub');
 
+    var args = [
+      '--webdriver=' + port,
+      '--webdriver-loglevel=DEBUG',
+      '--ssl-protocol=tlsv1',
+    ];
+
+    if (config.get('proxy.proxyType', 'direct') === 'manual') {
+      args.push('--proxy=127.0.0.1:' + config.get('proxy.port'));
+      args.push('--proxy-type=http');
+    }
+
     return {
       command: config.get('phantomjs.command', 'phantomjs'),
-      commandArgs: [
-        '--webdriver=' + port,
-        '--webdriver-loglevel=DEBUG',
-        '--ssl-protocol=tlsv1',
-      ],
+      commandArgs: args,
       port: port,
       verifyTimeout: config.get('phantomjs.timeout', 6000),
     };

--- a/lib/processes/proxy/index.js
+++ b/lib/processes/proxy/index.js
@@ -14,6 +14,13 @@ function getProxyOptions(config) {
     config.set('proxy.targetUrl', 'http://127.0.0.1:' + port);
     config.set('proxy.commandUrl', 'http://127.0.0.1:' + commandPort);
 
+    var proxyType = config.get('proxy.proxyType', 'direct');
+    if (proxyType === 'manual') {
+      var httpProxy = '127.0.0.1:' + config.get('proxy.port');
+      config.set('desiredCapabilities.proxy.proxyType', 'manual');
+      config.set('desiredCapabilities.proxy.httpProxy', httpProxy);
+    }
+
     return {
       dependsOn: config.getBool('launch', false) ? [ 'application' ] : [],
       command: process.execPath,

--- a/lib/processes/proxy/proxy.js
+++ b/lib/processes/proxy/proxy.js
@@ -10,14 +10,23 @@ var qs = require('qs');
 
 var modifyResponse = require('testium-cookie').modifyResponse;
 
-function buildRemoteRequestOptions(request, toPort) {
+function buildRemoteRequestOptions(request, fromPort, toPort) {
   var uri = parseUrl(request.url);
   var opt = {
-    port: toPort,
     path: uri.path,
     method: request.method,
     headers: request.headers,
   };
+
+  var hostHeader = request.headers.host;
+  if (!hostHeader || request.headers.host === '127.0.0.1:' + fromPort) {
+    opt.host = '127.0.0.1';
+    opt.port = toPort;
+  } else {
+    var parts = hostHeader.split(':');
+    opt.host = parts[0];
+    opt.port = parts[1];
+  }
 
   opt.headers.connection = 'keep-alive';
   opt.headers['cache-control'] = 'no-store';
@@ -28,6 +37,7 @@ function buildRemoteRequestOptions(request, toPort) {
 
 function normalizeOptions(options) {
   options.url = options.url || '/';
+  options.serverUrl = parseUrl(options.url).path;
   options.redirect = options.redirect === true || options.redirect === 'true';
   return options;
 }
@@ -48,7 +58,8 @@ function markNewPage(options, response, fromPort) {
   openRequests = [];
 
   if (options.redirect) {
-    var targetUrl = 'http://127.0.0.1:' + fromPort + options.url;
+    var targetUrl = options.url[0] === '/' ?
+      'http://127.0.0.1:' + fromPort + options.url : options.url;
     response.writeHead(302, {
       Location: targetUrl,
     });
@@ -57,12 +68,11 @@ function markNewPage(options, response, fromPort) {
   response.end();
 }
 
-function stripHash(url) {
-  return url.split('#')[0];
-}
-
 function isNewPage(url) {
-  return url === stripHash(newPageOptions.url);
+  // This completely ignores the hostname right now.
+  // Which shouldn't cause problems unless someone tries to load
+  // the exact same url from two hosts at the same time.
+  return url === newPageOptions.serverUrl;
 }
 
 function markRequestClosed(targetRequest) {
@@ -85,6 +95,7 @@ function emptySuccess(response) {
 function proxyCommand(url, options, response, fromPort) {
   switch (url) {
   case '/new-page':
+  case '/testium-new-page':
     return markNewPage(options, response, fromPort);
   default:
     return commandError(url, response);
@@ -101,8 +112,11 @@ function modifyRequest(request, options) {
   });
 }
 
-function proxyRequest(request, response, toPort) {
-  if (firstPage || request.url === '/testium-priming-load') {
+function proxyRequest(request, response, fromPort, toPort) {
+  var parsedUrl = parseUrl(request.url);
+  if (parsedUrl.pathname === '/testium-new-page') {
+    return markNewPage(qs.parse(parsedUrl.query), response, fromPort);
+  } else if (firstPage || parsedUrl.pathname === '/testium-priming-load') {
     firstPage = false;
     console.log('--> %s %s (prime the browser)', request.method, request.url);
     return emptySuccess(response);
@@ -110,8 +124,8 @@ function proxyRequest(request, response, toPort) {
 
   console.log('--> %s %s', request.method, request.url);
 
-  var remoteRequestOptions = buildRemoteRequestOptions(request, toPort);
-  if (isNewPage(request.url)) {
+  var remoteRequestOptions = buildRemoteRequestOptions(request, fromPort, toPort);
+  if (isNewPage(parsedUrl.path)) {
     modifyRequest(remoteRequestOptions, newPageOptions);
   }
   console.log('    %j', remoteRequestOptions);
@@ -119,7 +133,7 @@ function proxyRequest(request, response, toPort) {
   var remoteRequest = http.request(remoteRequestOptions, function forwardResponse(remoteResponse) {
     markRequestClosed(remoteRequest);
 
-    if (isNewPage(request.url)) {
+    if (isNewPage(parsedUrl.path)) {
       modifyResponse(remoteResponse);
     }
 
@@ -136,7 +150,7 @@ function proxyRequest(request, response, toPort) {
 
     markRequestClosed(remoteRequest);
 
-    if (isNewPage(request.url)) {
+    if (isNewPage(parsedUrl.path)) {
       modifyResponse(response);
     }
 
@@ -158,7 +172,7 @@ function proxyRequest(request, response, toPort) {
 module.exports =
 function startProxy(fromPort, toPort, commandPort) {
   var server = http.createServer(function handleProxy(request, response) {
-    proxyRequest(request, response, toPort);
+    proxyRequest(request, response, fromPort, toPort);
   });
   server.listen(fromPort);
   console.log('Listening on port %s and proxying to %s.', fromPort, toPort);

--- a/test/testium-core.js
+++ b/test/testium-core.js
@@ -96,6 +96,12 @@ describe('testium-core', () => {
       const echo = JSON.parse(browser.getElement('pre').get('text'));
       assert.equal('present', echo.headers['x-random-data']);
     });
+
+    it('can navigate to absolute urls', async () => {
+      const browser = await getBrowser();
+      browser.navigateTo('http://testiumjs.com/index.html');
+      assert.equal(200, await browser.getStatusCode());
+    });
   });
 
   describe('cross-test side effects', () => {


### PR DESCRIPTION
This turns the proxy into an actual proxy. E.g. using curl:

``` bash
# Step 1: Start proxy. Only 8080 matters, the other ports are mostly ignored now.
node lib/processes/proxy/child.js 8000 8080 8081
# Step 2: Load any URL (as long as it's http and not https)!
curl --proxy http://127.0.0.1:8080 http://testiumjs.com/api.html
```

This could be used together with the [following capabilities](https://code.google.com/p/selenium/wiki/DesiredCapabilities#Proxy_JSON_Object) (not properly tested yet):

``` yaml
proxy:
  proxyType: manual
  httpProxy: 'http://127.0.0.1:8080'
```

The bad news is that this conflicts with using a remote selenium instance since those might not be able to actually hit that url.
- [ ] Disable or implement proxying for https urls, right now it results in `curl: (56) Proxy CONNECT aborted`
