### PR TITLE
Initial URL is never the new page URL

### DIFF
--- a/lib/processes/proxy/proxy.js
+++ b/lib/processes/proxy/proxy.js
@@ -62,6 +62,7 @@ function stripHash(url) {
 }
 
 function isNewPage(url) {
+  if (!newPageOptions.url) return false;
   return url === stripHash(newPageOptions.url);
 }
 


### PR DESCRIPTION
When opening a URL before visiting any URL via `navigateTo '/url/path'`, the current code tries to call `split` on undefined. Which throws, crashing the proxy, and breaking testium completely.