### PR TITLE
fix: switch cleanly between driver types per-file

### DIFF
--- a/lib/driver-factory.js
+++ b/lib/driver-factory.js
@@ -33,6 +33,7 @@
 
 var debug = require('debug')('testium-core:driver-factory');
 var _ = require('lodash');
+var Bluebird = require('bluebird');
 
 function loadDriver(driverType) {
   debug('Loading driver', driverType);
@@ -75,10 +76,15 @@ var getDriverFactory = _.memoize(function createDriverFactory(createDriver) {
     // Exposed so that we can tell if priming is needed
     instance: null,
     once: function createDriverOnce(testium) {
-      if (!factory.instance) {
-        factory.instance = createDriver(testium);
+      if (factory.instance) {
+        testium.browser = factory.instance;
+        return Bluebird.resolve(testium);
       }
-      return factory.instance;
+
+      return Bluebird.resolve(createDriver(testium)).then(function saveInst() {
+        factory.instance = testium.browser;
+        return testium;
+      });
     },
   };
   return factory;

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "mocha": "^2.0.0",
     "nlm": "^2.0.0",
     "testium-driver-sync": "^1.0.3",
+    "testium-driver-wd": "^1.2.3",
     "testium-example-app": "^1.0.5"
   },
   "author": {

--- a/test/testium-core.test.js
+++ b/test/testium-core.test.js
@@ -106,4 +106,20 @@ describe('testium-core', () => {
       });
     });
   });
+
+  describe('getTestium', () => {
+    it('handles alternating drivers', async () => {
+      testium = await getTestium({ driver: 'wd' });
+      assert.hasType('first wd driver has assertStatusCode()',
+        Function, testium.browser.assertStatusCode);
+
+      testium = await getTestium({ driver: 'sync' });
+      assert.hasType('second sync driver has assert.* functions',
+        Object, testium.browser.assert);
+
+      testium = await getTestium({ driver: 'wd' });
+      assert.hasType('second wd driver has assertStatusCode()',
+        Function, testium.browser.assertStatusCode);
+    });
+  });
 });


### PR DESCRIPTION
Currently if you use `{ driver: 'wd' }` in the beforeHook()
options of one file and `{ driver: 'sync' }` in another, the
`browser` will still point at the previous driver's browser
object - this fixes that.

* wait for promise resolution after `createDriver()`
* save the browser from the result - the rest is just the same `testium` obj
* when using cached `factory.instance`, reset `testium.browser`