### PR TITLE
Environment variables are available in npm start scripts.

### DIFF
--- a/examples/hello-world/package.json
+++ b/examples/hello-world/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testium-core.hello-world",
   "scripts": {
-    "start": "node server.js Quinn"
+    "start": "DEBUG=* NODE_ENV=development node server.js Quinn"
   }
 }

--- a/lib/processes/application/index.js
+++ b/lib/processes/application/index.js
@@ -66,6 +66,14 @@ function getAppOptions(config) {
 
     var commandArgs = options.command.split(/[\s]+/g);
 
+    var envInCommand = {};
+
+    while (commandArgs.length && commandArgs[0].match('=')) {
+      var arg = commandArgs.shift();
+      var envPair = arg.split('=');
+      envInCommand[envPair[0]] = envPair[1];
+    }
+
     return _.extend(options, {
       command: commandArgs.shift(),
       commandArgs: commandArgs,
@@ -75,7 +83,7 @@ function getAppOptions(config) {
           NODE_ENV: config.get('launchEnv', 'test'),
           PORT: options.port,
           PATH: './node_modules/.bin:' + process.env.PATH,
-        }, process.env),
+        }, envInCommand, process.env),
         cwd: config.get('root'),
       },
     });

--- a/test/processes/application.test.js
+++ b/test/processes/application.test.js
@@ -14,6 +14,8 @@ describe('App', () => {
     const options = await App.getOptions(config);
     assert.hasType('Finds an open port', Number, options.port);
     assert.equal('Parses command from scripts.start', 'node', options.command);
+    assert.equal('Parses environment variables in scripts.start', '*', options.spawnOpts.env.DEBUG);
+    assert.equal('Does not override NODE_ENV', 'test', options.spawnOpts.env.NODE_ENV);
     assert.deepEqual('Parses commandArgs from scripts.start',
       ['server.js', 'Quinn'], options.commandArgs);
   });


### PR DESCRIPTION
fix #24 

Args with '=' are regarded as declaration of environment variables until one without '=' appears.

```sh
ABC=xxx XYZ=123 node server.js abc=xxx
#   |     |      |       |      |  
#   |     |      |     command-args
#   env-vars  command
```

```
