### PR TITLE
feat: use proxy.host for remote selenium grid

### DIFF
--- a/lib/processes/proxy/child.js
+++ b/lib/processes/proxy/child.js
@@ -36,5 +36,6 @@ var proxy = require('./proxy');
 var appPort = parseInt(process.argv[2], 10);
 var proxyPort = parseInt(process.argv[3], 10);
 var commandPort = parseInt(process.argv[4], 10);
+var proxyUrl = process.argv[5];
 
-proxy(proxyPort, appPort, commandPort);
+proxy(proxyPort, appPort, commandPort, proxyUrl);

--- a/lib/processes/proxy/index.js
+++ b/lib/processes/proxy/index.js
@@ -33,17 +33,44 @@
 
 var findOpenPort = require('find-open-port');
 var Bluebird = require('bluebird');
+var cp = Bluebird.promisifyAll(require('child_process'));
 
 exports.name = 'proxy';
 
 function getProxyOptions(config) {
-  function buildOptionsFromPort(port) {
+  function getProxyHost() {
+    var proxyHost = config.get('proxy.host', null);
+    var localPrefix = 'http://127.0.0.1:';
+
+    if (proxyHost) return Bluebird.resolve(proxyHost);
+
+    // if they didn't set the proxy.host, default it to localhost unless
+    // you're running a remote selenium.serverUrl, then default it to hostname
+    var selUrl = config.get('selenium.serverUrl', localPrefix);
+    if (/^http:\/\/(localhost|127\.0\.0\.1)\b/i.test(selUrl)) {
+      return Bluebird.resolve('127.0.0.1');
+    }
+
+    return cp.execFileAsync('hostname', ['-f'], { encoding: 'utf8' })
+             .call('trim');
+  }
+
+  function getProxyPort() {
+    // Defaulting to 4445 for backward compatibility
+    var port = config.get('proxy.port', 4445);
+    if (port === 0) {
+      return findOpenPort();
+    }
+    return Bluebird.resolve(port);
+  }
+
+  function buildOptions(proxyHost, port) {
     var appPort = config.get('app.port');
     var proxyModule = require.resolve('./child');
     var commandPort = 4446;
-
-    config.set('proxy.targetUrl', 'http://127.0.0.1:' + port);
-    config.set('proxy.commandUrl', 'http://127.0.0.1:' + commandPort);
+    var targetUrl = 'http://' + proxyHost + ':' + port;
+    config.set('proxy.targetUrl', targetUrl);
+    config.set('proxy.commandUrl', 'http://' + proxyHost + ':' + commandPort);
 
     return {
       dependsOn: config.getBool('launch', false) ? ['application'] : [],
@@ -53,18 +80,13 @@ function getProxyOptions(config) {
         '' + appPort,
         '' + port,
         '' + commandPort,
+        targetUrl,
       ],
       port: port,
       verifyTimeout: config.get('proxy.timeout', 6000),
     };
   }
 
-  // Defaulting to 4445 for backward compatibility
-  var port = config.get('proxy.port', 4445);
-
-  if (port === 0) {
-    return findOpenPort().then(buildOptionsFromPort);
-  }
-  return Bluebird.resolve(port).then(buildOptionsFromPort);
+  return Bluebird.all([getProxyHost(), getProxyPort()]).spread(buildOptions);
 }
 exports.getOptions = getProxyOptions;

--- a/lib/processes/proxy/proxy.js
+++ b/lib/processes/proxy/proxy.js
@@ -67,7 +67,7 @@ var openRequests = [];
 var firstPage = true;
 var newPageOptions = {};
 
-function markNewPage(options, response, fromPort) {
+function markNewPage(options, response, proxyUrl) {
   newPageOptions = normalizeOptions(options);
   console.log('\n[System] Marking new page request with options: %j', newPageOptions);
 
@@ -79,7 +79,8 @@ function markNewPage(options, response, fromPort) {
   openRequests = [];
 
   if (options.redirect) {
-    var targetUrl = 'http://127.0.0.1:' + fromPort + options.url;
+    var targetUrl = proxyUrl + options.url;
+    console.log('[System] 302 -> %s', targetUrl);
     response.writeHead(302, {
       Location: targetUrl,
     });
@@ -114,10 +115,10 @@ function emptySuccess(response) {
   response.end();
 }
 
-function proxyCommand(url, options, response, fromPort) {
+function proxyCommand(url, options, response, proxyUrl) {
   switch (url) {
     case '/new-page':
-      return markNewPage(options, response, fromPort);
+      return markNewPage(options, response, proxyUrl);
     default:
       return commandError(url, response);
   }
@@ -188,7 +189,7 @@ function proxyRequest(request, response, toPort) {
 }
 
 module.exports =
-function startProxy(fromPort, toPort, commandPort) {
+function startProxy(fromPort, toPort, commandPort, proxyUrl) {
   var server = http.createServer(function handleProxy(request, response) {
     proxyRequest(request, response, toPort);
   });
@@ -198,14 +199,19 @@ function startProxy(fromPort, toPort, commandPort) {
   var commandServer = http.createServer(function handleCommand(request, response) {
     if (request.method === 'GET') {
       var parsedUrl = parseUrl(request.url);
-      proxyCommand(parsedUrl.pathname, qs.parse(parsedUrl.query), response, fromPort);
+      proxyCommand(
+        parsedUrl.pathname,
+        qs.parse(parsedUrl.query),
+        response,
+        proxyUrl
+      );
     } else {
       request.pipe(concat(function withBody(body) {
         var options;
         if (body) {
           options = JSON.parse(body.toString());
         }
-        proxyCommand(request.url, options, response, fromPort);
+        proxyCommand(request.url, options, response, proxyUrl);
       }));
     }
   });

--- a/test/processes/proxy.test.js
+++ b/test/processes/proxy.test.js
@@ -1,4 +1,5 @@
 import path from 'path';
+import cp from 'child_process';
 
 import assert from 'assertive';
 
@@ -6,6 +7,10 @@ import Config from '../../lib/config';
 import App from '../../lib/processes/application';
 import Proxy from '../../lib/processes/proxy';
 import spawnServer from '../../lib/spawn-server';
+
+import Bluebird from 'bluebird';
+
+Bluebird.promisifyAll(cp);
 
 const HELLO_WORLD = path.resolve(__dirname, '../../examples/hello-world');
 
@@ -17,6 +22,18 @@ describe('Proxy', () => {
     assert.equal('Passes in the app port as the 2nd param to the child',
       '3041', options.commandArgs[1]);
     assert.equal('http://127.0.0.1:' + options.port, config.get('proxy.targetUrl'));
+  });
+
+  it('can generate remote-selenium spawn options', async () => {
+    const config = new Config(
+      { app: { port: 3041 }, selenium: { serverUrl: 'http://example.com' } }
+    );
+    const [options, hostname] = await Bluebird.all([
+      Proxy.getOptions(config),
+      cp.execFileAsync('hostname', ['-f'], { encoding: 'utf8' }).call('trim'),
+    ]);
+    assert.equal(`http://${hostname}:${options.port}`,
+                 config.get('proxy.targetUrl'));
   });
 
   it('can actually spawn', async () => {


### PR DESCRIPTION
* if `proxy.host` is set, it is used in URLs instead of 127.0.0.1
* if it is not set, but `selenium.serverUrl` is, it defaults to `hostname -f`
* this should allow network-reachable testium invocations to use selenium on a different host

TODO: document in https://github.com/testiumjs/testiumjs.github.io/blob/master/config.md#proxy