### PR TITLE
Add support for `proxy.tunnel`

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,3 @@
 {
-  "extends": "groupon/legacy"
+  "extends": "groupon-es5"
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/yarn.lock
 node_modules/
 /tmp
 npm-debug.log

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,8 @@
 This document outlines some of the practices we care about.
 If you have any questions or suggestions about the process,
 feel free to [open an issue](#reporting-issues)
-.
+ or [reach out to us directly](#contact).
+
 ## How Can I Contribute?
 
 ### Reporting Issues
@@ -145,3 +146,6 @@ A simple bug fix:
 fix: Handle multi-byte characters in search logic
 ```
 
+## Contact
+
+* Chat: [http://signup.testiumjs.com/](http://signup.testiumjs.com/)

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -59,7 +59,7 @@ module.exports = function getDefaults() {
     // connectTimeout = 2000
     // timeout = 60000
     webdriver: {
-      requestOptions: {},
+      requestOptions: {}
     },
 
     app: {
@@ -69,14 +69,14 @@ module.exports = function getDefaults() {
       timeout: 30000,
       // Command to start the app.
       // `undefined` means testium will simulate `npm start`
-      command: undefined,
+      command: undefined
     },
     phantomjs: {
       // Command to start phantomjs
       // Change this if you don't have phantomjs in your PATH
       command: 'phantomjs',
       // How long to wait for phantomjs to listen
-      timeout: 6000,
+      timeout: 6000
     },
     selenium: {
       // How long to wait for selenium to listen
@@ -93,14 +93,14 @@ module.exports = function getDefaults() {
       // `undefined` means "use testium built-in", see `jar` above.
       chromedriver: undefined,
       // Log debug info to selenium.log.
-      debug: true,
+      debug: true
     },
     repl: {
       // Module for the testium repl
       // If you want to use coffee-script in the repl, use:
       // * `module: coffee-script/repl` for coffee-script
       // * `module: coffee-script-redux/lib/repl` for redux
-      module: 'repl',
+      module: 'repl'
     },
     mixins: {
       // mixin modules allow you to add new methods to the browser
@@ -118,14 +118,14 @@ module.exports = function getDefaults() {
       browser: [],
       // Same as browser, only that it extends `browser.assert`.
       // Use this.browser to access the browser.
-      assert: [],
+      assert: []
     },
     mocha: {
       // mocha timeout for all tests that are in the suite the
       // browser was injected into.
       timeout: 20000,
       // Same, just for `slow`.
-      slow: 2000,
-    },
+      slow: 2000
+    }
   };
 };

--- a/lib/driver-factory.js
+++ b/lib/driver-factory.js
@@ -37,6 +37,7 @@ var Bluebird = require('bluebird');
 
 function loadDriver(driverType) {
   debug('Loading driver', driverType);
+  // eslint-disable-next-line global-require
   return require('testium-driver-' + driverType);
 }
 
@@ -85,7 +86,7 @@ var getDriverFactory = _.memoize(function createDriverFactory(createDriver) {
         factory.instance = testium.browser;
         return testium;
       });
-    },
+    }
   };
   return factory;
 }, strictEqualityResolver());

--- a/lib/init.js
+++ b/lib/init.js
@@ -63,7 +63,7 @@ function extendUrlWithQuery(url, queryArgs) {
   ));
 }
 
-function getNewPageUrl(commandUrl, url, options) {
+function getNewPageUrl(targetUrl, url, options) {
   options = options || {};
   var query = options.query;
   if (query) {
@@ -77,7 +77,7 @@ function getNewPageUrl(commandUrl, url, options) {
     return url;
   }
   options = _.defaults({ url: url, redirect: true }, _.omit(options, 'query'));
-  return commandUrl + '/new-page?' + qs.stringify(options);
+  return targetUrl + '/__testium_command__/new-page?' + qs.stringify(options);
 }
 
 function isTruthyConfig(setting) {
@@ -131,7 +131,7 @@ function initTestium(config) {
       close: close,
       config: config,
       getInitialUrl: getInitialUrl,
-      getNewPageUrl: _.partial(getNewPageUrl, config.get('proxy.commandUrl')),
+      getNewPageUrl: _.partial(getNewPageUrl, config.get('proxy.targetUrl'))
     };
     return testium;
   }

--- a/lib/init.js
+++ b/lib/init.js
@@ -150,7 +150,7 @@ function initTestium(config) {
         error.message = [
           'Error: Failed to connect to existing selenium server',
           '       - url: ' + seleniumUrl,
-          '       - message: ' + error.message,
+          '       - message: ' + error.message
         ].join('\n');
         error.stack = error.message + '\n' + oldStack;
         reject(error);

--- a/lib/processes/application/index.js
+++ b/lib/processes/application/index.js
@@ -74,17 +74,17 @@ function getAppOptions(config) {
         env: _.defaults({
           NODE_ENV: config.get('launchEnv', 'test'),
           PORT: options.port,
-          PATH: './node_modules/.bin:' + process.env.PATH,
+          PATH: './node_modules/.bin:' + process.env.PATH
         }, process.env),
-        cwd: config.get('root'),
-      },
+        cwd: config.get('root')
+      }
     });
   }
 
   var port = config.get('app.port', 0);
   return Bluebird.props({
     port: port === 0 ? findOpenPort() : port,
-    command: getLaunchCommand(config),
+    command: getLaunchCommand(config)
   }).then(buildOptions);
 }
 exports.getOptions = getAppOptions;

--- a/lib/processes/phantom/index.js
+++ b/lib/processes/phantom/index.js
@@ -46,10 +46,10 @@ function getPhantomOptions(config) {
       commandArgs: [
         '--webdriver=' + port,
         '--webdriver-loglevel=DEBUG',
-        '--ssl-protocol=tlsv1',
+        '--ssl-protocol=tlsv1'
       ],
       port: port,
-      verifyTimeout: config.get('phantomjs.timeout', 6000),
+      verifyTimeout: config.get('phantomjs.timeout', 6000)
     };
   }
 

--- a/lib/processes/proxy/child.js
+++ b/lib/processes/proxy/child.js
@@ -35,7 +35,6 @@ var proxy = require('./proxy');
 
 var appPort = parseInt(process.argv[2], 10);
 var proxyPort = parseInt(process.argv[3], 10);
-var commandPort = parseInt(process.argv[4], 10);
-var proxyUrl = process.argv[5];
+var proxyUrl = process.argv[4];
 
-proxy(proxyPort, appPort, commandPort, proxyUrl);
+proxy(proxyPort, appPort, proxyUrl);

--- a/lib/processes/proxy/index.js
+++ b/lib/processes/proxy/index.js
@@ -34,10 +34,15 @@
 var findOpenPort = require('find-open-port');
 var Bluebird = require('bluebird');
 var cp = Bluebird.promisifyAll(require('child_process'));
+var getTunnelProxyOptions = require('./tunnel');
 
 exports.name = 'proxy';
 
 function getProxyOptions(config) {
+  if (config.get('proxy.tunnel.host', null)) {
+    return getTunnelProxyOptions(config);
+  }
+
   function getProxyHost() {
     var proxyHost = config.get('proxy.host', null);
     var localPrefix = 'http://127.0.0.1:';
@@ -57,7 +62,7 @@ function getProxyOptions(config) {
 
   function getProxyPort() {
     // Defaulting to 4445 for backward compatibility
-    var port = config.get('proxy.port', 4445);
+    var port = parseInt(config.get('proxy.port', 4445), 10);
     if (port === 0) {
       return findOpenPort();
     }
@@ -67,10 +72,8 @@ function getProxyOptions(config) {
   function buildOptions(proxyHost, port) {
     var appPort = config.get('app.port');
     var proxyModule = require.resolve('./child');
-    var commandPort = 4446;
     var targetUrl = 'http://' + proxyHost + ':' + port;
     config.set('proxy.targetUrl', targetUrl);
-    config.set('proxy.commandUrl', 'http://' + proxyHost + ':' + commandPort);
 
     return {
       dependsOn: config.getBool('launch', false) ? ['application'] : [],
@@ -79,11 +82,10 @@ function getProxyOptions(config) {
         proxyModule,
         '' + appPort,
         '' + port,
-        '' + commandPort,
-        targetUrl,
+        targetUrl
       ],
       port: port,
-      verifyTimeout: config.get('proxy.timeout', 6000),
+      verifyTimeout: config.get('proxy.timeout', 6000)
     };
   }
 

--- a/lib/processes/proxy/proxy.js
+++ b/lib/processes/proxy/proxy.js
@@ -47,7 +47,7 @@ function buildRemoteRequestOptions(request, toPort) {
     port: toPort,
     path: uri.path,
     method: request.method,
-    headers: request.headers,
+    headers: request.headers
   };
 
   opt.headers.connection = 'keep-alive';
@@ -82,7 +82,7 @@ function markNewPage(options, response, proxyUrl) {
     var targetUrl = proxyUrl + options.url;
     console.log('[System] 302 -> %s', targetUrl);
     response.writeHead(302, {
-      Location: targetUrl,
+      Location: targetUrl
     });
   }
 
@@ -116,6 +116,7 @@ function emptySuccess(response) {
 }
 
 function proxyCommand(url, options, response, proxyUrl) {
+  console.log('~~> command: %s, %j', url, options);
   switch (url) {
     case '/new-page':
       return markNewPage(options, response, proxyUrl);
@@ -138,7 +139,8 @@ function proxyRequest(request, response, toPort) {
   if (firstPage || request.url === '/testium-priming-load') {
     firstPage = false;
     console.log('--> %s %s (prime the browser)', request.method, request.url);
-    return emptySuccess(response);
+    emptySuccess(response);
+    return;
   }
 
   console.log('--> %s %s', request.method, request.url);
@@ -189,32 +191,31 @@ function proxyRequest(request, response, toPort) {
 }
 
 module.exports =
-function startProxy(fromPort, toPort, commandPort, proxyUrl) {
+function startProxy(fromPort, toPort, proxyUrl) {
   var server = http.createServer(function handleProxy(request, response) {
-    proxyRequest(request, response, toPort);
+    var parsedUrl = parseUrl(request.url);
+    var m = parsedUrl.pathname.match(/^\/__testium_command__(\/.*)/);
+    if (m) {
+      if (request.method === 'GET') {
+        proxyCommand(
+          m[1],
+          qs.parse(parsedUrl.query),
+          response,
+          proxyUrl
+        );
+      } else {
+        request.pipe(concat(function withBody(body) {
+          var options;
+          if (body) {
+            options = JSON.parse(body.toString());
+          }
+          proxyCommand(parsedUrl.pathname, options, response, proxyUrl);
+        }));
+      }
+    } else {
+      proxyRequest(request, response, toPort);
+    }
   });
   server.listen(fromPort);
   console.log('Listening on port %s and proxying to %s.', fromPort, toPort);
-
-  var commandServer = http.createServer(function handleCommand(request, response) {
-    if (request.method === 'GET') {
-      var parsedUrl = parseUrl(request.url);
-      proxyCommand(
-        parsedUrl.pathname,
-        qs.parse(parsedUrl.query),
-        response,
-        proxyUrl
-      );
-    } else {
-      request.pipe(concat(function withBody(body) {
-        var options;
-        if (body) {
-          options = JSON.parse(body.toString());
-        }
-        proxyCommand(request.url, options, response, proxyUrl);
-      }));
-    }
-  });
-  commandServer.listen(commandPort);
-  console.log('Listening for commands on port %s.', commandPort);
 };

--- a/lib/processes/proxy/tunnel.js
+++ b/lib/processes/proxy/tunnel.js
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2015, Groupon, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * Neither the name of GROUPON nor the names of its contributors may be
+ * used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+'use strict';
+
+var tunnelSSH = require('reverse-tunnel-ssh');
+var debug = require('debug')('testium-core:proxy:tunnel');
+var Bluebird = require('bluebird');
+var findOpenPort = require('find-open-port');
+
+function getProxyPort(port) {
+  port = parseInt(port, 10);
+  if (port === 0) return findOpenPort();
+  return Bluebird.resolve(port);
+}
+
+function tunnelProxyPort(username, host, sshPort, srcPort, existingRemotePort) {
+  function makeSSHTunnel(proxyPort) {
+    // if there's already a tunnel set up for us
+    if (existingRemotePort) {
+      return Bluebird.resolve([proxyPort, existingRemotePort]);
+    }
+
+    return new Bluebird(function connectSSH(resolve) {
+      var conn = tunnelSSH({
+        host: host,
+        port: sshPort,
+        username: username,
+        dstHost: '0.0.0.0',
+        dstPort: 0, // dynamically allocate remote port
+        srcPort: proxyPort
+      }, function onTunnelConnect(err) {
+        if (err) console.error(err); // eslint-disable-line no-console
+      });
+      conn.on('forward-in', function onForward(destPort) {
+        debug('forwarding %s:%d -> localhost:%d', host, destPort, proxyPort);
+        resolve([proxyPort, destPort]);
+      });
+    });
+  }
+
+  return getProxyPort(srcPort).then(makeSSHTunnel);
+}
+
+function getTunnelProxyOptions(config) {
+  if (config.get('driver', 'sync') !== 'wd') {
+    throw new Error('proxy.tunnel only works with driver = wd');
+  }
+
+  // TODO: DRY some of this with index.js?
+  var appPort = config.get('app.port');
+  var proxyModule = require.resolve('./child');
+  var tunnelHost = config.get('proxy.tunnel.host');
+  var sshPort = config.get('proxy.tunnel.sshPort', 22);
+  var proxyHost = config.get('proxy.host', tunnelHost);
+  var proxyPort = config.get('proxy.port', 4445);
+  var username = config.get('proxy.tunnel.username', process.env.USER);
+  var existingRemotePort = config.get('proxy.tunnel.port', null);
+
+  return tunnelProxyPort(username, tunnelHost, sshPort, proxyPort,
+                         existingRemotePort)
+    .spread(function buildConfig(realProxyPort, remotePort) {
+      var targetUrl = 'http://' + proxyHost + ':' + remotePort;
+      config.set('proxy.targetUrl', targetUrl);
+      debug('proxy.targetUrl = ' + targetUrl);
+      return {
+        dependsOn: config.getBool('launch', false) ? ['application'] : [],
+        command: process.execPath,
+        commandArgs: [
+          proxyModule,
+          '' + appPort,
+          '' + realProxyPort,
+          targetUrl
+        ],
+        port: realProxyPort,
+        verifyTimeout: config.get('proxy.timeout', 6000)
+      };
+    });
+}
+
+module.exports = getTunnelProxyOptions;

--- a/lib/processes/selenium/index.js
+++ b/lib/processes/selenium/index.js
@@ -58,14 +58,14 @@ function createSeleniumArguments(chromeDriverPath) {
     '--disk-cache-size=1',
     '--disk-cache-dir=/dev/null',
     '--disable-cache',
-    '--disable-desktop-notifications',
+    '--disable-desktop-notifications'
   ].join(' ');
   var firefoxProfilePath = path.join(__dirname, './firefox-profile.js');
   return [
     '-Dwebdriver.chrome.driver=' + chromeDriverPath,
     '-Dwebdriver.chrome.args="' + chromeArgs + '"',
     '-firefoxProfileTemplate', firefoxProfilePath,
-    '-ensureCleanSession',
+    '-ensureCleanSession'
   ];
 }
 
@@ -92,7 +92,7 @@ function ensureFile(filename) {
         '$ ./node_modules/.bin/testium --download-selenium',
         '',
         'testium will download selenium and chromedriver into this directory:',
-        '  ' + BIN_PATH,
+        '  ' + BIN_PATH
       ].join('\n');
       error.stack = error.message + '\n' + oldStack;
       throw error;
@@ -132,7 +132,7 @@ function getSeleniumOptions(config) {
     var args = [
       '-Xmx256m',
       '-jar', jarPath,
-      '-port', '' + port,
+      '-port', '' + port
     ].concat(createSeleniumArguments(chromeDriverPath));
     if (config.get('selenium.debug', false)) {
       args.push('-debug');
@@ -141,13 +141,13 @@ function getSeleniumOptions(config) {
       command: 'java',
       commandArgs: args,
       port: port,
-      verifyTimeout: config.get('selenium.timeout', SELENIUM_TIMEOUT),
+      verifyTimeout: config.get('selenium.timeout', SELENIUM_TIMEOUT)
     };
   }
 
   return Bluebird.props({
     binaries: ensureBinaries(browserName, jarPath, chromeDriverPath),
-    port: getPort(config, 'selenium.port'),
+    port: getPort(config, 'selenium.port')
   }).then(buildOptions);
 }
 exports.getOptions = getSeleniumOptions;

--- a/lib/spawn-server.js
+++ b/lib/spawn-server.js
@@ -56,7 +56,7 @@ function spawnServer(config, servers) {
 
   function addDefaults(name, options) {
     return _.extend({
-      logFilePath: resolveLogFile(name),
+      logFilePath: resolveLogFile(name)
     }, options);
   }
 

--- a/lib/testium-core.js
+++ b/lib/testium-core.js
@@ -88,7 +88,7 @@ function getTestium(options) {
 
     error.message = [
       'Failed to initialize WebDriver. Check ' + logName + '.',
-      error.message,
+      error.message
     ].join('\n');
 
     throw error;

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "qs": "^4.0.0",
     "rc": "^1.1.1",
     "read-package-json": "^2.0.0",
+    "reverse-tunnel-ssh": "^1.1.0",
     "selenium-download": "^2.0.0",
     "subprocess": "~0.3.0",
     "testium-cookie": "^1.0.0"
@@ -51,8 +52,9 @@
     "gofer": "^2.4.5",
     "mocha": "^3.1.2",
     "nlm": "^3.0.0",
+    "ssh2": "^0.5.2",
     "testium-driver-sync": "^1.0.3",
-    "testium-driver-wd": "^1.2.3",
+    "testium-driver-wd": "^1.3.0",
     "testium-example-app": "^1.0.5"
   },
   "author": {

--- a/package.json
+++ b/package.json
@@ -40,15 +40,17 @@
     "testium-cookie": "^1.0.0"
   },
   "devDependencies": {
-    "assertive": "^2.0.0",
+    "assertive": "^2.1.0",
     "babel-core": "^5.8.25",
     "babel-eslint": "^4.1.3",
     "cookie": "~0.1.3",
-    "eslint": "^1.0.0",
-    "eslint-config-groupon": "^2.0.0",
+    "eslint": "^2.0.0",
+    "eslint-config-groupon": "^3.2.0",
+    "eslint-config-groupon-es5": "^3.2.0",
+    "eslint-plugin-import": "^1.6.1",
     "gofer": "^2.4.5",
-    "mocha": "^2.0.0",
-    "nlm": "^2.0.0",
+    "mocha": "^3.1.2",
+    "nlm": "^3.0.0",
     "testium-driver-sync": "^1.0.3",
     "testium-driver-wd": "^1.2.3",
     "testium-example-app": "^1.0.5"

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,5 +1,5 @@
 {
-  "extends": "groupon/base",
+  "extends": "groupon",
   "env": {
     "mocha": true
   },

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -16,7 +16,7 @@ function enterDirectory(relative) {
 describe('Config', () => {
   describe('Config::set', () => {
     let config;
-    beforeEach(() => config = new Config({ original: 42 }));
+    beforeEach(() => { config = new Config({ original: 42 }); });
 
     it('changes existing values', () => {
       config.set('original', 13);
@@ -31,13 +31,15 @@ describe('Config', () => {
 
   describe('Config::getBool', () => {
     let config;
-    beforeEach(() => config = new Config({
-      boolFalse: false,
-      boolTrue: true,
-      strFalse: 'false',
-      strTrue: 'true',
-      str0: '0',
-    }));
+    beforeEach(() => {
+      config = new Config({
+        boolFalse: false,
+        boolTrue: true,
+        strFalse: 'false',
+        strTrue: 'true',
+        str0: '0',
+      });
+    });
 
     it('handles bools and strings correctly', () => {
       assert.equal(false, config.getBool('boolFalse'));
@@ -93,7 +95,7 @@ describe('Config', () => {
       enterDirectory('../examples/rcfile');
 
       let config;
-      beforeEach(() => config = Config.load());
+      beforeEach(() => { config = Config.load(); });
 
       it('reads `launch` from the rc file', () => {
         assert.equal('launch is correctly read from the rc file',

--- a/test/processes/phantom.test.js
+++ b/test/processes/phantom.test.js
@@ -12,7 +12,7 @@ describe('Phantom', () => {
     const options = await Phantom.getOptions(config);
     assert.hasType('Finds an open port', Number, options.port);
     assert.equal('Sets the selenium server url',
-      'http://127.0.0.1:' + options.port + '/wd/hub',
+      `http://127.0.0.1:${options.port}/wd/hub`,
       config.get('selenium.serverUrl'));
   });
 

--- a/test/processes/proxy.test.js
+++ b/test/processes/proxy.test.js
@@ -21,7 +21,7 @@ describe('Proxy', () => {
     assert.hasType('Finds an open port', Number, options.port);
     assert.equal('Passes in the app port as the 2nd param to the child',
       '3041', options.commandArgs[1]);
-    assert.equal('http://127.0.0.1:' + options.port, config.get('proxy.targetUrl'));
+    assert.equal(`http://127.0.0.1:${options.port}`, config.get('proxy.targetUrl'));
   });
 
   it('can generate remote-selenium spawn options', async () => {

--- a/test/processes/proxy.test.js
+++ b/test/processes/proxy.test.js
@@ -26,7 +26,7 @@ describe('Proxy', () => {
 
   it('can generate remote-selenium spawn options', async () => {
     const config = new Config(
-      { app: { port: 3041 }, selenium: { serverUrl: 'http://example.com' } }
+      { app: { port: '3041' }, selenium: { serverUrl: 'http://example.com' } }
     );
     const [options, hostname] = await Bluebird.all([
       Proxy.getOptions(config),
@@ -39,10 +39,26 @@ describe('Proxy', () => {
   it('can actually spawn', async () => {
     const config = new Config({
       root: HELLO_WORLD,
-      app: { port: 3041 },
+      app: { port: '3041' },
     });
     const { proxy, application } = await spawnServer(config, [Proxy, App]);
     proxy.rawProcess.kill();
     application.rawProcess.kill();
   });
+
+  it('can use an already tunneled port', async () => {
+    const config = new Config({
+      root: HELLO_WORLD,
+      app: { port: '3041' },
+      driver: 'wd',
+      proxy: { tunnel: { host: 'tun-host', port: '4242' } },
+    });
+    const { proxy, application } = await spawnServer(config, [Proxy, App]);
+    assert.equal('http://tun-host:4242', proxy.launchArguments[3]);
+    proxy.rawProcess.kill();
+    application.rawProcess.kill();
+  });
+
+  // TODO: something with ./ssh-server
+  it('can open an ssh tunnel to the proxy');
 });

--- a/test/processes/selenium.test.js
+++ b/test/processes/selenium.test.js
@@ -17,7 +17,7 @@ describe('Selenium', () => {
     selenium.rawProcess.kill();
 
     assert.equal('Sets the selenium server url',
-      'http://127.0.0.1:' + config.get('selenium.port') + '/wd/hub',
+      `http://127.0.0.1:${config.get('selenium.port')}/wd/hub`,
       config.get('selenium.serverUrl'));
   });
 });

--- a/test/processes/ssh-server.js
+++ b/test/processes/ssh-server.js
@@ -1,0 +1,61 @@
+import ssh2 from 'ssh2';
+import Bluebird from 'bluebird';
+
+const hostKey = `
+-----BEGIN RSA PRIVATE KEY-----
+MIIEpAIBAAKCAQEA71O2DVsM32sWWRxGD4wRx/AxFFcPpu9KwJ2KstDG1DXqPN86
+OfFCEqGgeQ5Oz+OXQq/fIOXg82ueex6Sr6bW/aM8sBxB87bA2CS7bG7VS6PJrx9u
+9IEly7CzBuz3ePuO9DfrWz9UsMA5614sZbrecbIGrO+6KEFHzk2+rpMPea0+O1fq
+hvO6pIVfhE1wI4sdjd4M8/joWfewe4Bn5oFYPvlTx9J4ws573+LUnts891lmFvXD
+0nM43bFs5Ovn0amA83MPk4EdyOjLzZTBWxD4DS9C5u3Z1XOysYD9FWNB2DSipYuO
+xVlT9maU23+c3BAOV1SveOX5exKHoEiAiHtDdQIDAQABAoIBAHzTRpL0uGQXMJLN
+wmT9g5Cq4I5hUlKZYH3SLbNSXUH11PRm4bGy+elJz68UHVsks5IetNwtygRsTz6c
+FZn0BRJJf6/DLUr2OOMDVZYawLkw9lKWrIJukc4JnXaxReoeGtOaDvGKuJtvx0XR
+2oo8yyS12/F7H7c7RT5/IkNfhKTLCwHRMnaKGOyLkQ36ab8xhf/6T/4pd9PcKzr8
+eupUcGOVawDCICaOJecr4jx1AXotjhm9f+FvSfUW4pV9bz0toxyQ+iCpoSTITQ/J
+VlwVY5iNEVX7hgtKHkawJCCSX/AJ9qSoZ31LlHVXG0Y5XeEfyVPeI9E9iYx0gaEe
+QuOFBckCgYEA+ZQpVLPcTLUISnADfDsPEJl9vcRWxAxvWf90YsNs0Bm0HG8tMgp+
+toUYvhNrgR7Ltxrcr4WxVLFz0PF3gWz/75sRYHk1PZa0A7rzLg/gh68E6PdC19sZ
+MokY6v06roKcUHdbC85FCcju/ht6S5Np1ctp+haUK9KfMfe3A/L2eMMCgYEA9XwG
+55wlSeg0jwntegelRyKoaq7tCPyiCHPAPmydfbw6Af2zqfae2s8lJc4sB+I0+lj7
+yK4+n34uuQ07mHJ+/wwcErLLuE4OPh5qlnGNKL2LYkGnl6dH3tTxQQRiB6AdT7B3
+RQQHHELcIspZ6obQLDTsw1GfiV7UgBxaooL5z2cCgYBY0Krso5zwBzROGRKEcRfp
+VlXy5B3kYnB13Hx0cQsV+y+nNsEkn6t8FF07tvl415azMHH8XF1AwG1wm51lh36E
+q/BBHqEdq7Wf5jWH3MqQPm5G4Ub+Pc/3teYSKc9qLrylvfO+fcb/tmumLe0VW/47
+wMmT39kWxzszsu2EEEA5tQKBgQCZxw4UPI5nU9zI1fE7hlqUyzMxUU8PWCKwpMIC
+2Mt3nlfAM4s+p00vyJ9+pT6T2bJSOTfQqMZ15veh2JZCk0bWwmE7nWFcnRjy9N7U
+S2Gf6czMylAQAixVfJN8pSA7oqN57hNo2nMR0xhPeu8EqVrytlyypgkIZq07a4ej
+UeTndQKBgQDK4xfc3WgXWzuGHCDtESxnNVntrYvTld03OGnwDCxhmlXgdyw1qOn1
+J+UIrqAQTmzgU+rTrz7SrPtl8V0PzySiyqo6qx/I/1BfVw893jtWj2zX2LuxBWAg
++O9MI/SyGfgAdm0FmNcnknLEJBuVqjxuKC2LdSZY2iRMoWQI0Lw6cQ==
+-----END RSA PRIVATE KEY-----
+`.trim();
+
+function startSSHServer() {
+  const opts = { hostKeys: [hostKey] };
+  return new Bluebird(resolve => {
+    const server = new ssh2.Server(opts, client => {
+      client.on('authentication', ctx => { ctx.accept(); })
+            .on('ready', () => {
+              client.on('session', acceptSession => {
+                const session = acceptSession();
+                // something other than exec?
+                session.once('exec', acceptExec => { acceptExec(); });
+                // eslint-disable-next-line no-unused-vars
+                session.on('request', (acceptReq, rejectReq, name, data) => {
+                  acceptReq();
+                });
+                // eslint-disable-next-line no-unused-vars
+                session.on('tcpip', (acceptT, rejectT, tData) => {
+                  acceptT();
+                });
+              });
+            });
+    });
+    server.listen(0, '127.0.0.1', function onListen() {
+      resolve(this.address().port);
+    });
+  });
+}
+
+module.exports = startSSHServer;

--- a/test/spawn-server.test.js
+++ b/test/spawn-server.test.js
@@ -6,7 +6,7 @@ import spawnServer from '../lib/spawn-server';
 describe('spawnServer', () => {
   it('spawns a simple node http server', async () => {
     const { helloWorld } = await spawnServer(new Config({
-      root: __dirname + '/tmp/server',
+      root: `${__dirname}/tmp/server`,
     }), {
       name: 'helloWorld',
       getOptions() {
@@ -28,7 +28,7 @@ describe('spawnServer', () => {
   it('handles a child that fails to start', async () => {
     try {
       await spawnServer(new Config({
-        root: __dirname + '/tmp/server',
+        root: `${__dirname}/tmp/server`,
       }), {
         name: 'throws',
         getOptions() {
@@ -50,7 +50,7 @@ describe('spawnServer', () => {
   it('fails for a child that takes too long to listen', async () => {
     try {
       await spawnServer(new Config({
-        root: __dirname + '/tmp/server',
+        root: `${__dirname}/tmp/server`,
       }), {
         name: 'hello-world',
         getOptions() {

--- a/test/testium-core.test.js
+++ b/test/testium-core.test.js
@@ -37,7 +37,7 @@ describe('testium-core', () => {
 
     it('supports additional options', async () => {
       const response = await fetchResponse(
-        testium.getNewPageUrl('/echo', { query: { 'x': 'y' } }), { json: true });
+        testium.getNewPageUrl('/echo', { query: { x: 'y' } }), { json: true });
 
       const echo = response.body;
       assert.truthy('Sends a valid JSON response', echo);
@@ -46,7 +46,7 @@ describe('testium-core', () => {
 
       assert.truthy('Sets a cookie', response.headers['set-cookie']);
       assert.include('Sets a _testium_ cookie',
-        '_testium_=', '' + response.headers['set-cookie']);
+        '_testium_=', `${response.headers['set-cookie']}`);
     });
   });
 


### PR DESCRIPTION
Now a setup like this will work:

```ini
driver = wd
browser = chrome
selenium.serverUrl = http://selenium.example.com::4444/wd/hub
proxy.tunnel.host = some-externally-accessible-server.example.net
```

* only works with `driver = wd`
* remote ssh server must have `GatewayPorts yes` in `sshd_config`
* if you set `proxy.tunnel.host`, the proxy setup will create an ssh tunnel from a random port on that host thru to `proxy.port` (default 4445) on localhost
* if you also set `proxy.tunnel.port`, it will assume you've already done the ssh and use that port in URLs
* if you set `proxy.tunnel.username`, that will be used for the ssh, else `process.env.USER`
* if you set `proxy.tunnel.sshPort`, that will be used instead of 22
* if you set `proxy.host` (just in case there's an external vs. internal hostname), that will be used in the proxy.targetUrl, else `proxy.tunnel.host` will be used
* there's no longer a command port on 4446 - now it just reuses the proxy app with prefix `/__testium_command__`

TODO: better test of ssh client - still trying to figure out how to properly write `test/processes/ssh-server.js`

This PR also includes some NLM updates.
