### PR TITLE
feat: tunnel: checks ~/.ssh for keys if no agent

### DIFF
--- a/lib/processes/proxy/tunnel.js
+++ b/lib/processes/proxy/tunnel.js
@@ -35,11 +35,29 @@ var tunnelSSH = require('reverse-tunnel-ssh');
 var debug = require('debug')('testium-core:proxy:tunnel');
 var Bluebird = require('bluebird');
 var findOpenPort = require('find-open-port');
+var fs = require('fs');
+var os = require('os');
+var path = require('path');
 
 function getProxyPort(port) {
   port = parseInt(port, 10);
   if (port === 0) return findOpenPort();
   return Bluebird.resolve(port);
+}
+
+function findPrivateKey() {
+  debug('No SSH_AUTH_SOCK found; looking for private key files in ~/.ssh');
+  var dir = path.join(os.homedir(), '.ssh');
+  var candidates = ['id_rsa', 'id_ecdsa', 'id_dsa'];
+  for (var i = 0; i < candidates.length; i++) {
+    var cand = path.join(dir, candidates[i]);
+    try {
+      return fs.readFileSync(cand);
+    } catch (err) {
+      debug("findPrivateKey(): couldn't load " + cand, err);
+    }
+  }
+  throw new Error('proxy.tunnel failed: no SSH_AUTH_SOCK env var set and no keys found in ~/.ssh');
 }
 
 function tunnelProxyPort(username, host, sshPort, srcPort, existingRemotePort) {
@@ -49,6 +67,9 @@ function tunnelProxyPort(username, host, sshPort, srcPort, existingRemotePort) {
       return Bluebird.resolve([proxyPort, existingRemotePort]);
     }
 
+    var privateKey;
+    if (!process.env.SSH_AUTH_SOCK) privateKey = findPrivateKey();
+
     return new Bluebird(function connectSSH(resolve) {
       var conn = tunnelSSH({
         host: host,
@@ -56,7 +77,8 @@ function tunnelProxyPort(username, host, sshPort, srcPort, existingRemotePort) {
         username: username,
         dstHost: '0.0.0.0',
         dstPort: 0, // dynamically allocate remote port
-        srcPort: proxyPort
+        srcPort: proxyPort,
+        privateKey: privateKey
       }, function onTunnelConnect(err) {
         if (err) console.error(err); // eslint-disable-line no-console
       });

--- a/test/processes/proxy.test.js
+++ b/test/processes/proxy.test.js
@@ -18,20 +18,25 @@ describe('Proxy', () => {
   it('can generate spawn options', async () => {
     const config = new Config({ app: { port: 3041 } });
     const options = await Proxy.getOptions(config);
-    assert.hasType('Finds an open port', Number, options.port);
+    assert.equal('Uses default port', 4445, options.port);
     assert.equal('Passes in the app port as the 2nd param to the child',
       '3041', options.commandArgs[1]);
     assert.equal(`http://127.0.0.1:${options.port}`, config.get('proxy.targetUrl'));
   });
 
   it('can generate remote-selenium spawn options', async () => {
-    const config = new Config(
-      { app: { port: '3041' }, selenium: { serverUrl: 'http://example.com' } }
-    );
+    const config = new Config({
+      app: { port: '3041' },
+      selenium: { serverUrl: 'http://example.com' },
+      proxy: { port: '0' },
+    });
     const [options, hostname] = await Bluebird.all([
       Proxy.getOptions(config),
       cp.execFileAsync('hostname', ['-f'], { encoding: 'utf8' }).call('trim'),
     ]);
+    assert.hasType('Finds an open port', Number, options.port);
+    assert.expect('Port is no longer 0', options.port > 0);
+    assert.notEqual('Port is not default', 4445, options.port);
     assert.equal(`http://${hostname}:${options.port}`,
                  config.get('proxy.targetUrl'));
   });
@@ -40,6 +45,7 @@ describe('Proxy', () => {
     const config = new Config({
       root: HELLO_WORLD,
       app: { port: '3041' },
+      proxy: { port: '0' },
     });
     const { proxy, application } = await spawnServer(config, [Proxy, App]);
     proxy.rawProcess.kill();
@@ -51,7 +57,7 @@ describe('Proxy', () => {
       root: HELLO_WORLD,
       app: { port: '3041' },
       driver: 'wd',
-      proxy: { tunnel: { host: 'tun-host', port: '4242' } },
+      proxy: { port: '0', tunnel: { host: 'tun-host', port: '4242' } },
     });
     const { proxy, application } = await spawnServer(config, [Proxy, App]);
     assert.equal('http://tun-host:4242', proxy.launchArguments[3]);


### PR DESCRIPTION
`reverse-tunnel-ssh` sets `agent` for you in the `ssh2` options if you have `SSH_AUTH_SOCK`, but otherwise needs private keys - this adds a check for obvious locations for them - won't work for keys with passphrase, but automation systems won't have encrypted private keys anyway, riiiiiight?