### PR TITLE
fix: properly invoke selenium.jar with -debug flag

### DIFF
--- a/lib/processes/selenium/index.js
+++ b/lib/processes/selenium/index.js
@@ -132,8 +132,8 @@ function getSeleniumOptions(config) {
         '-jar', jarPath,
         '-port', '' + port
       ]);
-    if (config.get('selenium.debug', false)) {
-      args.push('-debug');
+    if (config.getBool('selenium.debug', false)) {
+      args.push('-debug', 'true');
     }
     return {
       command: 'java',


### PR DESCRIPTION
* `-debug` now takes an argument
* `selenium.debug` option should be `getBool()` to be false-able

Fixes https://github.com/testiumjs/testium-core/issues/34