### PR TITLE
selenium invocation -debug argument

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ test/tmp
 examples/**/log
 test/log
 bin
+/package-lock.json

--- a/lib/processes/selenium/index.js
+++ b/lib/processes/selenium/index.js
@@ -132,9 +132,7 @@ function getSeleniumOptions(config) {
         '-jar', jarPath,
         '-port', '' + port
       ]);
-    if (config.getBool('selenium.debug', false)) {
-      args.push('-debug', 'true');
-    }
+    if (config.getBool('selenium.debug', false)) args.push('-debug');
     return {
       command: 'java',
       commandArgs: args,


### PR DESCRIPTION
The selenium jar switched (back) to just `-debug` and not `-debug true`

Fixes errors like:

```
Exception in thread "main" com.beust.jcommander.ParameterException: Was
passed main parameter 'true' but no main parameter was defined in your
arg class
```