### PR TITLE
use chromedriver directly without jar

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,18 +2,14 @@ language: node_js
 node_js:
   - '4'
   - '6'
-before_install:
-  - npm install -g npm@latest-2
-before_deploy:
-  - 'git config --global user.email "opensource@groupon.com"'
-  - 'git config --global user.name "Groupon"'
+  - '8'
 deploy:
   provider: script
   script: ./node_modules/.bin/nlm release
   skip_cleanup: true
   'on':
     branch: master
-    node: '6'
+    node: '8'
 env:
   - CXX=g++-4.8
 addons:

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -78,6 +78,17 @@ module.exports = function getDefaults() {
       // How long to wait for phantomjs to listen
       timeout: 6000
     },
+    chrome: {
+      // path to already-installed chrome binary - otherwise uses chromedriver
+      // default
+      command: undefined,
+      // run chrome in headless mode - defaults to false if $DISPLAY is set,
+      // true otherwise
+      headless: undefined,
+      // Path to chromedriver.
+      // if `undefined` it will try to be loaded from the "chromedriver" module
+      chromedriver: undefined
+    },
     selenium: {
       // How long to wait for selenium to listen
       timeout: 90000,
@@ -86,12 +97,9 @@ module.exports = function getDefaults() {
       serverUrl: undefined,
       // Path to selenium jar.
       // `undefined` means "use testium built-in".
-      // Using the testium built-in binaries requires you to run
-      // `testium --download-selenium` before running your tests.
+      // Using the testium built-in binary means it will be automatically
+      // downloaded the first time your tests run
       jar: undefined,
-      // Path to chromedriver.
-      // `undefined` means "use testium built-in", see `jar` above.
-      chromedriver: undefined,
       // Log debug info to selenium.log.
       debug: true
     },

--- a/lib/processes.js
+++ b/lib/processes.js
@@ -41,6 +41,7 @@ var Phantom = require('./processes/phantom');
 var Proxy = require('./processes/proxy');
 var App = require('./processes/application');
 var Selenium = require('./processes/selenium');
+var ChromeDriver = require('./processes/chromedriver');
 
 function unrefAll(procs) {
   // Make sure these processes don't keep the parent alive
@@ -70,10 +71,32 @@ function launchAllProcesses(config) {
 
     var seleniumUrl = config.get('selenium.serverUrl', false);
     if (!seleniumUrl) {
-      debug('Will launch selenium server for %j', browserName);
-      servers.push(browserName === 'phantomjs' ? Phantom : Selenium);
+      debug('Will launch webdriver server for %j', browserName);
+      servers.push({
+        phantomjs: Phantom,
+        chrome: ChromeDriver
+      }[browserName] || Selenium);
     } else {
       debug('Using existing selenium server', seleniumUrl);
+    }
+
+    if (browserName === 'chrome') {
+      var chromePath = config.get('chrome.command', null);
+      if (chromePath) {
+        config.set('desiredCapabilities.chromeOptions.binary', chromePath);
+      }
+      var args = config.get('desiredCapabilities.chromeOptions.args', [
+        '--disable-application-cache',
+        '--media-cache-size=1',
+        '--disk-cache-size=1',
+        '--disk-cache-dir=/dev/null',
+        '--disable-cache',
+        '--disable-desktop-notifications'
+      ]);
+      if (config.get('chrome.headless', !process.env.DISPLAY)) {
+        args.push('--headless');
+      }
+      config.set('desiredCapabilities.chromeOptions.args', args);
     }
 
     return spawnServers(config, servers)

--- a/lib/processes/chromedriver/index.js
+++ b/lib/processes/chromedriver/index.js
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2015, Groupon, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * Neither the name of GROUPON nor the names of its contributors may be
+ * used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+'use strict';
+
+var util = require('util');
+var cp = require('child_process');
+var debug = require('debug')('testium-core:chromedriver');
+
+var findOpenPort = require('find-open-port');
+
+exports.name = 'chromedriver';
+
+function throwPrettyError(error) {
+  var oldStack = error.stack;
+  error.message = [
+    'Could not find required files for running chromedriver.',
+    '       - message: ' + error.message,
+    '',
+    'You can provide your own version of chromedriver via ~/.testiumrc:',
+    '',
+    '```',
+    '[chrome]',
+    'chromedriver = /path/to/chromedriver',
+    '```',
+    '',
+    'or you can install the "chromedriver" npm module and its',
+    'downloaded copy will be used automatically'
+  ].join('\n');
+  error.stack = error.message + '\n' + oldStack;
+  throw error;
+}
+
+function oldPath(config) {
+  var cdPath = config.get('selenium.chromedriver', null);
+  if (cdPath) {
+    util.deprecate(
+      function deprecated() {},
+      'selenium.chromedriver is deprecated, use chrome.chromedriver'
+    )();
+  }
+  debug('oldPath: ', cdPath);
+  return cdPath;
+}
+
+function pathFromModule() {
+  var cdPath;
+  try {
+    // eslint-disable-next-line global-require, import/no-unresolved
+    cdPath = require('chromedriver').path;
+  } catch (err) {
+    if (err.code !== 'MODULE_NOT_FOUND') throw err;
+  }
+  debug('pathFromModule: ', cdPath);
+  return cdPath;
+}
+
+function confirmInPATH() {
+  var cdPath = 'chromedriver';
+  try {
+    cp.execFileSync(cdPath, ['--version']);
+  } catch (err) {
+    throwPrettyError(err);
+  }
+  debug('confirmInPATH', cdPath);
+  return cdPath;
+}
+
+function getChromedriverOptions(config) {
+  var chromeDriverPath = config.get('chrome.chromedriver', null)
+    || oldPath(config)
+    || pathFromModule()
+    || confirmInPATH();
+
+  var logLevel = config.get('chrome.logLevel', 'ALL');
+
+  return findOpenPort().then(function withPort(port) {
+    config.set('selenium.serverUrl', 'http://127.0.0.1:' + port);
+    return {
+      command: chromeDriverPath,
+      commandArgs: ['--port=%port%', '--log-level=' + logLevel],
+      port: port
+    };
+  });
+}
+exports.getOptions = getChromedriverOptions;

--- a/lib/processes/selenium/index.js
+++ b/lib/processes/selenium/index.js
@@ -43,28 +43,12 @@ var SELENIUM_TIMEOUT = 90000;
 
 var BIN_PATH = path.join(__dirname, '..', '..', '..', 'bin');
 var DEFAULT_JAR_PATH = path.join(BIN_PATH, 'selenium.jar');
-var DEFAULT_CHROME_PATH = path.join(BIN_PATH, 'chromedriver');
 
 var statAsync = Bluebird.promisify(fs.stat);
 var downloadSelenium =
   _.partial(Bluebird.promisify(SeleniumDownload.ensure), BIN_PATH);
 
 exports.name = 'selenium';
-
-function createSeleniumArguments(chromeDriverPath) {
-  var chromeArgs = [
-    '--disable-application-cache',
-    '--media-cache-size=1',
-    '--disk-cache-size=1',
-    '--disk-cache-dir=/dev/null',
-    '--disable-cache',
-    '--disable-desktop-notifications'
-  ].join(' ');
-  return [
-    '-Dwebdriver.chrome.driver=' + chromeDriverPath,
-    '-Dwebdriver.chrome.args="' + chromeArgs + '"'
-  ];
-}
 
 function ensureFile(filename) {
   return statAsync(filename)
@@ -79,8 +63,6 @@ function ensureFile(filename) {
         '```',
         '[selenium]',
         'jar = /path/to/selenium.jar',
-        '; For running tests in chrome:',
-        'chromedriver = /path/to/chromedriver',
         '```',
         '',
         'testium can also download these files for you,',
@@ -88,7 +70,7 @@ function ensureFile(filename) {
         '',
         '$ ./node_modules/.bin/testium --download-selenium',
         '',
-        'testium will download selenium and chromedriver into this directory:',
+        'testium will download selenium into this directory:',
         '  ' + BIN_PATH
       ].join('\n');
       error.stack = error.message + '\n' + oldStack;
@@ -96,14 +78,10 @@ function ensureFile(filename) {
     });
 }
 
-function ensureBinaries(browserName, jarPath, chromeDriverPath) {
+function ensureBinaries(browserName, jarPath) {
   var files = [ensureFile(jarPath)];
-  if (browserName === 'chrome') {
-    files.push(ensureFile(chromeDriverPath));
-  }
   return Bluebird.all(files).catch(function gracefulDownload(error) {
-    var usingDefaultFiles =
-      jarPath === DEFAULT_JAR_PATH && chromeDriverPath === DEFAULT_CHROME_PATH;
+    var usingDefaultFiles = jarPath === DEFAULT_JAR_PATH;
     if (usingDefaultFiles && error.code === 'ENOENT') {
       return downloadSelenium();
     }
@@ -118,7 +96,6 @@ function getPort(config, key) {
 
 function getSeleniumOptions(config) {
   var jarPath = config.get('selenium.jar', DEFAULT_JAR_PATH);
-  var chromeDriverPath = config.get('selenium.chromedriver', DEFAULT_CHROME_PATH);
   var browserName = config.get('browser');
 
   function buildOptions(data) {
@@ -127,7 +104,6 @@ function getSeleniumOptions(config) {
     config.set('selenium.serverUrl', 'http://127.0.0.1:' + port + '/wd/hub');
 
     var args = ['-Xmx256m']
-      .concat(createSeleniumArguments(chromeDriverPath))
       .concat([
         '-jar', jarPath,
         '-port', '' + port
@@ -142,7 +118,7 @@ function getSeleniumOptions(config) {
   }
 
   return Bluebird.props({
-    binaries: ensureBinaries(browserName, jarPath, chromeDriverPath),
+    binaries: ensureBinaries(browserName, jarPath),
     port: getPort(config, 'selenium.port')
   }).then(buildOptions);
 }

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "assertive": "^2.1.0",
     "babel-core": "^5.8.25",
     "babel-eslint": "^4.1.3",
+    "chromedriver": "^2.38.3",
     "cookie": "~0.1.3",
     "eslint": "^2.0.0",
     "eslint-config-groupon": "^3.2.0",
@@ -54,7 +55,7 @@
     "nlm": "^3.0.0",
     "ssh2": "^0.5.2",
     "testium-driver-sync": "^1.0.3",
-    "testium-driver-wd": "^1.3.0",
+    "testium-driver-wd": "^2.3.0",
     "testium-example-app": "^1.0.5"
   },
   "author": {
@@ -97,6 +98,10 @@
     {
       "name": "Sean Massa",
       "email": "endangeredmassa@gmail.com"
+    },
+    {
+      "name": "David Bushong",
+      "email": "david@bushong.net"
     }
   ],
   "keywords": [

--- a/test/processes/chromedriver.test.js
+++ b/test/processes/chromedriver.test.js
@@ -1,0 +1,79 @@
+import path from 'path';
+import fs from 'fs';
+
+import assert from 'assertive';
+import mkdirp from 'mkdirp-then';
+
+import Config from '../../lib/config';
+import ChromeDriver from '../../lib/processes/chromedriver';
+import spawnServer from '../../lib/spawn-server';
+
+const browser = 'chrome';
+const root = path.resolve(__dirname, '../tmp/chromedriver');
+
+const tmpCDPath = `${root}/chromedriver/lib/chromedriver/chromedriver`;
+
+async function startChromeDriver(cfg) {
+  const config = new Config({ browser, root, ...cfg });
+  const { chromedriver } = await spawnServer(config, ChromeDriver);
+  chromedriver.rawProcess.kill();
+
+  assert.match('Sets the selenium server url',
+    /^http:\/\/127.0.0.1:\d+$/,
+    config.get('selenium.serverUrl')
+  );
+}
+
+describe('ChromeDriver', () => {
+  before(() => {
+    try {
+      fs.unlinkSync(`${__dirname}/../../node_modules/.bin/chromedriver`);
+    } catch (err) {
+      /* ignored */
+    }
+    return mkdirp(root);
+  });
+
+  afterEach(() => {
+    process.env.PATH =
+      process.env.PATH.replace(/[^:]+\/lib\/chromedriver:/, '');
+  });
+
+  describe('without chromedriver module', () => {
+    before(() => {
+      fs.renameSync(
+        `${__dirname}/../../node_modules/chromedriver`,
+        `${root}/chromedriver`
+      );
+    });
+
+    after(() => {
+      fs.renameSync(
+        `${root}/chromedriver`,
+        `${__dirname}/../../node_modules/chromedriver`
+      );
+    });
+
+    it('errors out prettily if none found', async () => {
+      const err = await assert.rejects(startChromeDriver());
+      assert.include('You can provide your own', err.stack);
+    });
+
+    it('uses the chrome.chromedriver setting', () =>
+      startChromeDriver({ chrome: { chromedriver: tmpCDPath } }));
+
+    it('uses the chrome.chromedriver setting', () =>
+      startChromeDriver({ selenium: { chromedriver: tmpCDPath } }));
+
+    it('finds chromedriver in $PATH', async () => {
+      process.env.PATH += `:${path.dirname(tmpCDPath)}`;
+      await startChromeDriver();
+    });
+  });
+
+  // this must be last, and in a describe, otherwise it pollutes the require
+  // cache in a way I can't figure out how to clear properly
+  describe('with chromedriver module', () => {
+    it('finds chromedriver from module', () => startChromeDriver());
+  });
+});


### PR DESCRIPTION
* create new `chrome` config section
* let `chromedriver` be configurable there
* allow `chrome.command` to be configured
* make `chrome.headless` an auto-defaulting option
* try to use `chromedriver` module for path if available
* fallback on `chromedriver` in `$PATH`

This + `testium-driver-wd` >= 2.3.0 supports headless chrome:

```
$ npm i -D chromedriver
```

```rc
browser = chrome

[chrome]
headless = true
```

chromedriver will no longer be automatically downloaded, as the
`selenium-download` code is not triggered by `browser = chrome`
automatically, but you can just include the `chromedriver` module
in your `devDependencies` to achieve a similar result