### PR TITLE
Pass remote debugging port for chrome

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -134,9 +134,9 @@ function initTestium(config) {
     testium = {
       close: close,
       config: config,
+      getChromeDevtoolsPort: getChromeDevtoolsPort,
       getInitialUrl: getInitialUrl,
-      getNewPageUrl: _.partial(getNewPageUrl, config.get('proxy.targetUrl')),
-      getChromeDevtoolsPort: getChromeDevtoolsPort
+      getNewPageUrl: _.partial(getNewPageUrl, config.get('proxy.targetUrl'))
     };
     return testium;
   }

--- a/lib/init.js
+++ b/lib/init.js
@@ -127,11 +127,16 @@ function initTestium(config) {
       return config.get('proxy.targetUrl') + '/testium-priming-load';
     }
 
+    function getChromeDevtoolsPort() {
+      return config.get('chrome.remoteDebuggingPort', null);
+    }
+
     testium = {
       close: close,
       config: config,
       getInitialUrl: getInitialUrl,
-      getNewPageUrl: _.partial(getNewPageUrl, config.get('proxy.targetUrl'))
+      getNewPageUrl: _.partial(getNewPageUrl, config.get('proxy.targetUrl')),
+      getChromeDevtoolsPort: getChromeDevtoolsPort
     };
     return testium;
   }

--- a/lib/processes.js
+++ b/lib/processes.js
@@ -97,6 +97,15 @@ function launchAllProcesses(config) {
         args.push('--headless');
       }
       if (process.getuid() === 0) args.push('--no-sandbox');
+
+      var debugPort = config.get('chrome.--remote-debugging-port');
+      if (debugPort) {
+        findOpenPort().then(function (port) {
+          args.push('--remote-debugging-port=' + port);
+          config.set('chrome.--remote-debugging-port', port);
+        });
+      }
+
       config.set('desiredCapabilities.chromeOptions.args', args);
     }
 

--- a/lib/processes.js
+++ b/lib/processes.js
@@ -51,6 +51,11 @@ function unrefAll(procs) {
   return procs;
 }
 
+function setChromeDevtoolsPort(port, args, config) {
+  args.push('--remote-debugging-port=' + port);
+  config.set('chrome.remoteDebuggingPort', port);
+}
+
 function launchAllProcesses(config) {
   var launchApp = config.getBool('launch', false);
 
@@ -98,12 +103,14 @@ function launchAllProcesses(config) {
       }
       if (process.getuid() === 0) args.push('--no-sandbox');
 
-      var debugPort = config.get('chrome.--remote-debugging-port');
-      if (debugPort) {
+      var debugPort = config.get('chrome.remoteDebuggingPort', null);
+
+      if (!debugPort || debugPort === 0) {
         findOpenPort().then(function (port) {
-          args.push('--remote-debugging-port=' + port);
-          config.set('chrome.--remote-debugging-port', port);
+          setChromeDevtoolsPort(port, args, config);
         });
+      } else {
+        setChromeDevtoolsPort(debugPort, args, config);
       }
 
       config.set('desiredCapabilities.chromeOptions.args', args);

--- a/lib/processes.js
+++ b/lib/processes.js
@@ -52,6 +52,7 @@ function unrefAll(procs) {
 }
 
 function setChromeDevtoolsPort(port, args, config) {
+  debug('remoteDebuggingPort', port);
   args.push('--remote-debugging-port=' + port);
   config.set('chrome.remoteDebuggingPort', port);
 }

--- a/lib/processes.js
+++ b/lib/processes.js
@@ -51,12 +51,6 @@ function unrefAll(procs) {
   return procs;
 }
 
-function setChromeDevtoolsPort(port, args, config) {
-  debug('remoteDebuggingPort', port);
-  args.push('--remote-debugging-port=' + port);
-  config.set('chrome.remoteDebuggingPort', port);
-}
-
 function launchAllProcesses(config) {
   var launchApp = config.getBool('launch', false);
 
@@ -104,15 +98,11 @@ function launchAllProcesses(config) {
       }
       if (process.getuid() === 0) args.push('--no-sandbox');
 
-      var debugPort = config.get('chrome.remoteDebuggingPort', null);
-
-      if (!debugPort || debugPort === 0) {
-        findOpenPort().then(function (port) {
-          setChromeDevtoolsPort(port, args, config);
-        });
-      } else {
-        setChromeDevtoolsPort(debugPort, args, config);
-      }
+      findOpenPort().then(function (port) {
+        args.push('--remote-debugging-port=' + port);
+        config.set('chrome.remoteDebuggingPort', port);
+        debug('remoteDebuggingPort', port);
+      });
 
       config.set('desiredCapabilities.chromeOptions.args', args);
     }


### PR DESCRIPTION
Set '--remote-debugging-port' in testium config, which would be consumed by lighthouse to talk with testium.

### Line of Thought: 

**Step 1**: [Indidvidual apps] Add flag `--remote-debugging-port` to _.testiumrc_ in the App's repo

**Step 2**: [testium-core] Use this flag to pass to chromedriver/chrome by either directly using the port number or by finding next available port. Also update the testium property, if new port number was used

**Step 3**: [testium-driver-wd] Add `getPort` method as wd chain methods to fetch the testium property
```
  wd.addPromiseChainMethod('getPort', function getPort() {
    let debugPort = testium.config.get('chrome.--remote-debugging-port');
    debug('Remote dubugging port set as', debugPort);
    return debugPort;
  });
```

**Step 4**: [Individual apps or itier-accessibility] Port fetch from `browser.getPort` would be used to pass it to lighthouse
```
 browser.getPort()
    .then(port => lighthouse(url, Object.assign({}, opts, { port }), config))
    .then(results => new Promise(res => res(results.audits)));
```