### PR TITLE
chore: add --disable-dev-shm-usage for chromeOptions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
-  - '4'
   - '6'
   - '8'
+  - '10'
 deploy:
   provider: script
   script: ./node_modules/.bin/nlm release

--- a/lib/processes.js
+++ b/lib/processes.js
@@ -56,10 +56,7 @@ function isChromeInDocker(browserName) {
   var fileName = '/.dockerenv';
   return new Bluebird(function promoise(resolve, reject) {
     fs.stat(fileName, function fsCb(err, stats) {
-      if (err) {
-        reject(err);
-      }
-      resolve(stats);
+      return err ? reject(err) : resolve(stats);
     });
   });
 }

--- a/lib/processes.js
+++ b/lib/processes.js
@@ -31,6 +31,9 @@
  */
 'use strict';
 
+var fs = require('fs');
+
+var Bluebird = require('bluebird');
 var findOpenPort = require('find-open-port');
 var _ = require('lodash');
 var debug = require('debug')('testium-core:processes');
@@ -42,6 +45,24 @@ var Proxy = require('./processes/proxy');
 var App = require('./processes/application');
 var Selenium = require('./processes/selenium');
 var ChromeDriver = require('./processes/chromedriver');
+
+var CHROME = 'chrome';
+
+function isChromeInDocker(browserName) {
+  if (browserName !== CHROME) {
+    return Bluebird.reject();
+  }
+
+  var fileName = '/.dockerenv';
+  return new Bluebird(function promoise(resolve, reject) {
+    fs.stat(fileName, function fsCb(err, stats) {
+      if (err) {
+        reject(err);
+      }
+      resolve(stats);
+    });
+  });
+}
 
 function unrefAll(procs) {
   // Make sure these processes don't keep the parent alive
@@ -80,7 +101,7 @@ function launchAllProcesses(config) {
       debug('Using existing selenium server', seleniumUrl);
     }
 
-    if (browserName === 'chrome') {
+    if (browserName === CHROME) {
       var chromePath = config.get('chrome.command', null);
       if (chromePath) {
         config.set('desiredCapabilities.chromeOptions.binary', chromePath);
@@ -91,18 +112,25 @@ function launchAllProcesses(config) {
         '--disk-cache-size=1',
         '--disk-cache-dir=/dev/null',
         '--disable-cache',
-        '--disable-desktop-notifications',
-        '--disable-dev-shm-usage'
+        '--disable-desktop-notifications'
       ]);
       if (config.get('chrome.headless', !process.env.DISPLAY)) {
         args.push('--headless');
       }
       if (process.getuid() === 0) args.push('--no-sandbox');
-      config.set('desiredCapabilities.chromeOptions.args', args);
+
+      return isChromeInDocker(browserName).then(function isDockerEnv() {
+        debug('Running in docker env');
+        args.push('--disable-dev-shm-usage');
+      }).catch(function isNotDockerEnv() {
+        debug('Not running in docker env');
+      }).then(function setChromeOptions() {
+        config.set('desiredCapabilities.chromeOptions.args', args);
+        return spawnServers(config, servers);
+      }).then(unrefAll);
     }
 
-    return spawnServers(config, servers)
-      .then(unrefAll);
+    return spawnServers(config, servers).then(unrefAll);
   }
 
   // app.port is special because the proxy needs to know it

--- a/lib/processes.js
+++ b/lib/processes.js
@@ -54,7 +54,7 @@ function isChromeInDocker(browserName) {
   }
 
   var fileName = '/.dockerenv';
-  return new Bluebird(function promoise(resolve, reject) {
+  return new Bluebird(function promise(resolve, reject) {
     fs.stat(fileName, function fsCb(err, stats) {
       return err ? reject(err) : resolve(stats);
     });

--- a/lib/processes.js
+++ b/lib/processes.js
@@ -91,7 +91,8 @@ function launchAllProcesses(config) {
         '--disk-cache-size=1',
         '--disk-cache-dir=/dev/null',
         '--disable-cache',
-        '--disable-desktop-notifications'
+        '--disable-desktop-notifications',
+        '--disable-dev-shm-usage'
       ]);
       if (config.get('chrome.headless', !process.env.DISPLAY)) {
         args.push('--headless');

--- a/package.json
+++ b/package.json
@@ -50,13 +50,17 @@
     "eslint-config-groupon": "^3.2.0",
     "eslint-config-groupon-es5": "^3.2.0",
     "eslint-plugin-import": "^1.6.1",
+    "fs-monkey": "^0.3.3",
     "gofer": "^2.4.5",
+    "memfs": "^2.14.2",
     "mocha": "^3.1.2",
     "nlm": "^3.0.0",
+    "sinon": "^7.2.2",
     "ssh2": "^0.5.2",
     "testium-driver-sync": "^1.0.3",
     "testium-driver-wd": "^2.3.0",
-    "testium-example-app": "^1.0.5"
+    "testium-example-app": "^1.0.5",
+    "unionfs": "^3.0.2"
   },
   "author": {
     "name": "Groupon",

--- a/test/processes.test.js
+++ b/test/processes.test.js
@@ -6,9 +6,20 @@ import { each } from 'lodash';
 import Config from '../lib/config';
 import launchAllProcesses from '../lib/processes';
 
+import { patchFs } from 'fs-monkey';
+import { ufs } from 'unionfs';
+import { Volume } from 'memfs';
+import * as fs from 'fs';
+
+import sinon from 'sinon';
+
 const HELLO_WORLD = path.resolve(__dirname, '../examples/hello-world');
 
-describe('Launch all processes', () => {
+function killProcs(procs) {
+  each(procs, ({ rawProcess }) => rawProcess.kill());
+}
+
+describe('Launch all processes PhantomJS', () => {
   const config = new Config({
     root: HELLO_WORLD,
     launch: true,
@@ -20,6 +31,71 @@ describe('Launch all processes', () => {
     const procNames = Object.keys(procs).sort();
     assert.deepEqual('Spawns app, phantom, and proxy',
       ['application', 'phantomjs', 'proxy'], procNames);
-    each(procs, ({ rawProcess }) => rawProcess.kill());
+    killProcs(procs);
+  });
+});
+
+describe('Launch all processes Chrome', () => {
+  const chromeOptions = [
+    '--disable-application-cache',
+    '--media-cache-size=1',
+    '--disk-cache-size=1',
+    '--disk-cache-dir=/dev/null',
+    '--disable-cache',
+    '--disable-desktop-notifications',
+    '--headless'];
+
+  let config;
+  beforeEach(() => {
+    config = new Config({
+      root: HELLO_WORLD,
+      launch: true,
+      browser: 'chrome',
+    });
+  });
+
+  afterEach(() => {
+    config = null;
+  });
+
+  it('launches all the processes', async () => {
+    const procs = await launchAllProcesses(config);
+    const procNames = Object.keys(procs).sort();
+    assert.deepEqual('Spawns app, chrome, and proxy',
+      ['application', 'chromedriver', 'proxy'], procNames);
+    killProcs(procs);
+  });
+
+  it('has the correct chromeOptions when NOT IN docker container', async () => {
+    const procs = await launchAllProcesses(config);
+    const { args } = config.desiredCapabilities.chromeOptions;
+    assert.deepEqual(chromeOptions, args);
+    killProcs(procs);
+  });
+
+  it('runs has --no-sandbox when run as root', async () => {
+    const getuidStub = sinon.stub(process, 'getuid').returns(0);
+
+    const procs = await launchAllProcesses(config);
+    const { args } = config.desiredCapabilities.chromeOptions;
+    assert.deepEqual([...chromeOptions, '--no-sandbox'], args);
+    getuidStub.restore();
+    killProcs(procs);
+  });
+
+  it('has the correct chromeOptions when IN docker container', async () => {
+    // simulate docker file system
+    const vol = Volume.fromJSON({
+      '/.dockerenv': 'docker',
+    });
+    ufs.use(fs).use(vol); // build fileystem
+    const unpatch = patchFs(ufs); // patch native fs calls
+
+    const procs = await launchAllProcesses(config);
+    const { args } = config.desiredCapabilities.chromeOptions;
+    assert.deepEqual([...chromeOptions, '--disable-dev-shm-usage'], args);
+    killProcs(procs);
+
+    unpatch();
   });
 });


### PR DESCRIPTION
See: https://bugs.chromium.org/p/chromium/issues/detail?id=736452

from Google Dev Troubleshooting: https://developers.google.com/web/tools/puppeteer/troubleshooting

> By default, Docker runs a container with a /dev/shm shared memory space 64MB. This is typically too small for Chrome and will cause Chrome to crash when rendering large pages. To fix, run the container with docker run --shm-size=1gb to increase the size of /dev/shm. Since Chrome 65, this is no longer necessary. Instead, launch the browser with the --disable-dev-shm-usage flag: