### PR TITLE
Change default driver to wd

### DIFF
--- a/lib/testium-core.js
+++ b/lib/testium-core.js
@@ -75,7 +75,7 @@ function getTestium(options) {
 
   var reuseSession = localConfig.get('reuseSession', true);
   var keepCookies = localConfig.get('keepCookies', false);
-  var driverFactory = resolveDriver(localConfig.get('driver', 'sync'));
+  var driverFactory = resolveDriver(localConfig.get('driver', 'wd'));
 
   var isExistingSession = reuseSession && !!driverFactory.instance;
   var skipPriming = isExistingSession;

--- a/test/testium-core.test.js
+++ b/test/testium-core.test.js
@@ -1,17 +1,17 @@
 import assert from 'assertive';
 import Gofer from 'gofer';
-import Bluebird from 'bluebird';
 
 import { getTestium, getBrowser } from '../';
 
 const gofer = new Gofer({
   globalDefaults: {},
 });
-function fetch(uri, options) {
-  return Bluebird.resolve(gofer.fetch(uri, options));
+
+async function fetch(uri, options) {
+  return gofer.fetch(uri, options);
 }
-function fetchResponse(uri, options) {
-  return Bluebird.resolve(gofer.fetch(uri, options).getResponse());
+async function fetchResponse(uri, options) {
+  return gofer.fetch(uri, options).getResponse();
 }
 
 describe('testium-core', () => {


### PR DESCRIPTION
* feat: Change default driver to `wd`
* test: use `async` instead of Bluebird promises

BREAKING CHANGE: This change will force existent clients
to update their code to either explicitly use the sync
driver or use the async API

---
_This PR was started by: [git wf pr](https://github.com/groupon/git-workflow/releases/tag/v1.0.3)_