### PR TITLE
stop specifying disk cache as /dev/null

### DIFF
--- a/lib/processes.js
+++ b/lib/processes.js
@@ -131,7 +131,6 @@ function launchAllProcesses(config) {
         '--disable-application-cache',
         '--media-cache-size=1',
         '--disk-cache-size=1',
-        '--disk-cache-dir=/dev/null',
         '--disable-cache',
         '--disable-desktop-notifications',
       ];

--- a/test/processes.test.js
+++ b/test/processes.test.js
@@ -57,7 +57,6 @@ describe('Launch all processes Chrome', () => {
     '--disable-application-cache',
     '--media-cache-size=1',
     '--disk-cache-size=1',
-    '--disk-cache-dir=/dev/null',
     '--disable-cache',
     '--disable-desktop-notifications',
     '--headless',
@@ -212,8 +211,8 @@ describe('Launch all processes Chrome', () => {
           [
             ...chromeOptions.slice(0, 2),
             '--disk-cache-size=2',
+            ...chromeOptions.slice(3),
             '--disk-cache-dir=./tmp',
-            ...chromeOptions.slice(4),
           ],
           args
         );


### PR DESCRIPTION
it breaks ChromeDriver 95+(?), and shouldn't be needed with
`--disable-cache`

---
_This PR was started by: [git wf pr](https://github.com/groupon/git-workflow/releases/tag/v1.3.4)_