### PR TITLE
parse package.json "start" env vars correctly

### DIFF
--- a/examples/complex-start/package.json
+++ b/examples/complex-start/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "testium-core.complex-start",
+  "scripts": {
+    "start": "FOO=bar=baz NODE_ENV=test npx foo --flag=value"
+  }
+}

--- a/lib/processes/application/index.js
+++ b/lib/processes/application/index.js
@@ -67,19 +67,25 @@ function getAppOptions(config) {
 
     const commandArgs = options.command.split(/\s+/g);
 
+    const customEnv = {};
+    let m;
+    while ((m = (commandArgs[0] || '').match(/^([^=]+)=(.*)/))) {
+      commandArgs.shift();
+      customEnv[m[1]] = m[2];
+    }
+
     return _.extend(options, {
       command: commandArgs.shift(),
       commandArgs,
       verifyTimeout: config.get('app.timeout', 30000),
       spawnOpts: {
-        env: _.defaults(
-          {
-            NODE_ENV: config.get('launchEnv', 'test'),
-            PORT: options.port,
-            PATH: `./node_modules/.bin:${process.env.PATH}`,
-          },
-          process.env
-        ),
+        env: {
+          NODE_ENV: config.get('launchEnv', 'test'),
+          PORT: options.port,
+          PATH: `./node_modules/.bin:${process.env.PATH}`,
+          ...process.env,
+          ...customEnv,
+        },
         cwd: config.get('root'),
       },
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
       "devDependencies": {
         "assertive": "^5.0.5",
         "c8": "^7.7.3",
-        "chromedriver": "^96.0.0",
+        "chromedriver": "^95.0.0",
         "cookie": "^0.4.0",
         "eslint": "^7.29.0",
         "eslint-config-groupon": "^10.0.4",
@@ -1127,9 +1127,9 @@
       }
     },
     "node_modules/chromedriver": {
-      "version": "96.0.0",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-96.0.0.tgz",
-      "integrity": "sha512-4g6Hn5RHGsbaBmOrJbDlz/hdVPOc22eRsbvoAAMqkZxR2NJCcddHzCw2FAQeW8lX/C7xWVz3nyDsKX3fE9lIIw==",
+      "version": "95.0.0",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-95.0.0.tgz",
+      "integrity": "sha512-HwSg7S0ZZYsHTjULwxFHrrUqEpz1+ljDudJM3eOquvqD5QKnR5pSe/GlBTY9UU2tVFRYz8bEHYC4Y8qxciQiLQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -8039,9 +8039,9 @@
       }
     },
     "chromedriver": {
-      "version": "96.0.0",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-96.0.0.tgz",
-      "integrity": "sha512-4g6Hn5RHGsbaBmOrJbDlz/hdVPOc22eRsbvoAAMqkZxR2NJCcddHzCw2FAQeW8lX/C7xWVz3nyDsKX3fE9lIIw==",
+      "version": "95.0.0",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-95.0.0.tgz",
+      "integrity": "sha512-HwSg7S0ZZYsHTjULwxFHrrUqEpz1+ljDudJM3eOquvqD5QKnR5pSe/GlBTY9UU2tVFRYz8bEHYC4Y8qxciQiLQ==",
       "dev": true,
       "requires": {
         "@testim/chrome-version": "^1.0.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
       "devDependencies": {
         "assertive": "^5.0.5",
         "c8": "^7.7.3",
-        "chromedriver": "^94.0.0",
+        "chromedriver": "^96.0.0",
         "cookie": "^0.4.0",
         "eslint": "^7.29.0",
         "eslint-config-groupon": "^10.0.4",
@@ -1127,9 +1127,9 @@
       }
     },
     "node_modules/chromedriver": {
-      "version": "94.0.0",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-94.0.0.tgz",
-      "integrity": "sha512-x4hK7R7iOyAhdLHJEcOyGBW/oa2kno6AqpHVLd+n3G7c2Vk9XcAXMz84XhNItqykJvTc6E3z/JRIT1eHYH//Eg==",
+      "version": "96.0.0",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-96.0.0.tgz",
+      "integrity": "sha512-4g6Hn5RHGsbaBmOrJbDlz/hdVPOc22eRsbvoAAMqkZxR2NJCcddHzCw2FAQeW8lX/C7xWVz3nyDsKX3fE9lIIw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -8039,9 +8039,9 @@
       }
     },
     "chromedriver": {
-      "version": "94.0.0",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-94.0.0.tgz",
-      "integrity": "sha512-x4hK7R7iOyAhdLHJEcOyGBW/oa2kno6AqpHVLd+n3G7c2Vk9XcAXMz84XhNItqykJvTc6E3z/JRIT1eHYH//Eg==",
+      "version": "96.0.0",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-96.0.0.tgz",
+      "integrity": "sha512-4g6Hn5RHGsbaBmOrJbDlz/hdVPOc22eRsbvoAAMqkZxR2NJCcddHzCw2FAQeW8lX/C7xWVz3nyDsKX3fE9lIIw==",
       "dev": true,
       "requires": {
         "@testim/chrome-version": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   "devDependencies": {
     "assertive": "^5.0.5",
     "c8": "^7.7.3",
-    "chromedriver": "^94.0.0",
+    "chromedriver": "^96.0.0",
     "cookie": "^0.4.0",
     "eslint": "^7.29.0",
     "eslint-config-groupon": "^10.0.4",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   "devDependencies": {
     "assertive": "^5.0.5",
     "c8": "^7.7.3",
-    "chromedriver": "^96.0.0",
+    "chromedriver": "^95.0.0",
     "cookie": "^0.4.0",
     "eslint": "^7.29.0",
     "eslint-config-groupon": "^10.0.4",

--- a/test/processes/application.test.js
+++ b/test/processes/application.test.js
@@ -9,6 +9,7 @@ const App = require('../../lib/processes/application');
 const spawnServer = require('../../lib/spawn-server');
 
 const HELLO_WORLD = path.resolve(__dirname, '../../examples/hello-world');
+const COMPLEX_START = path.resolve(__dirname, '../../examples/complex-start');
 
 describe('App', () => {
   it('can generate spawn options', async () => {
@@ -19,6 +20,19 @@ describe('App', () => {
     assert.deepEqual(
       'Parses commandArgs from scripts.start',
       ['server.js', 'Quinn'],
+      options.commandArgs
+    );
+  });
+
+  it('gracefully handles ENV=value prefixes', async () => {
+    const config = new Config({ root: COMPLEX_START });
+    const options = await App.getOptions(config);
+    assert.equal('Parses command from scripts.start', 'npx', options.command);
+    assert.equal('test', options.spawnOpts.env.NODE_ENV);
+    assert.equal('bar=baz', options.spawnOpts.env.FOO);
+    assert.deepEqual(
+      'Parses commandArgs from scripts.start',
+      ['foo', '--flag=value'],
       options.commandArgs
     );
   });


### PR DESCRIPTION
before, in `package.json`:
```
  "start": "NODE_OPTIONS=--x npx foo",
```

would break, trying to treat the first part as the command; now it works

Ideally we'd just invoke `spawn()` with `command` set to the entire cmd
line and pass `shell: true`, but this would result in our pid not being
quite right which might cause other problems...

---
_This PR was started by: [git wf pr](https://github.com/groupon/git-workflow/releases/tag/v1.3.4)_